### PR TITLE
Fix/store decryption key on confirm

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -24,6 +24,7 @@ pub struct Swap {
     pub usdc_amount: i128,
     pub usdc_token: Address,
     pub status: SwapStatus,
+    pub decryption_key: Option<Bytes>,
 }
 
 #[contracttype]
@@ -57,7 +58,7 @@ impl AtomicSwap {
         env.storage().instance().set(&DataKey::Counter, &id);
         env.storage().instance().set(
             &DataKey::Swap(id),
-            &Swap { listing_id, buyer, seller, usdc_amount, usdc_token, status: SwapStatus::Pending },
+            &Swap { listing_id, buyer, seller, usdc_amount, usdc_token, status: SwapStatus::Pending, decryption_key: None },
         );
         id
     }
@@ -79,6 +80,7 @@ impl AtomicSwap {
             &swap.usdc_amount,
         );
         swap.status = SwapStatus::Completed;
+        swap.decryption_key = Some(decryption_key);
         env.storage().instance().set(&DataKey::Swap(swap_id), &swap);
     }
 
@@ -108,16 +110,28 @@ impl AtomicSwap {
             .expect("swap not found");
         swap.status
     }
+
+    /// Returns the decryption key once the swap is completed.
+    pub fn get_decryption_key(env: Env, swap_id: u64) -> Option<Bytes> {
+        let swap: Swap = env
+            .storage()
+            .instance()
+            .get(&DataKey::Swap(swap_id))
+            .expect("swap not found");
+        swap.decryption_key
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::Env;
+    use soroban_sdk::{
+        testutils::Address as _,
+        token, Env,
+    };
 
     #[test]
     fn test_swap_status_pending_on_initiate() {
-        // Full token mock integration tested via scripts; unit-check enum variants compile.
         let _ = SwapStatus::Pending;
         let _ = SwapStatus::Completed;
         let _ = SwapStatus::Cancelled;
@@ -130,5 +144,39 @@ mod test {
         let contract_id = env.register(AtomicSwap, ());
         let client = AtomicSwapClient::new(&env, &contract_id);
         client.confirm_swap(&0, &Bytes::new(&env));
+    }
+
+    #[test]
+    fn test_decryption_key_accessible_after_confirmation() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        // Deploy a Stellar asset (USDC stand-in) and mint to buyer
+        let usdc_admin = Address::generate(&env);
+        let usdc_id = env.register_stellar_asset_contract_v2(usdc_admin.clone()).address();
+        let usdc_admin_client = token::StellarAssetClient::new(&env, &usdc_id);
+        let usdc_client = token::Client::new(&env, &usdc_id);
+
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        usdc_admin_client.mint(&buyer, &1000);
+
+        // Deploy swap contract
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        // Buyer initiates swap
+        let swap_id = client.initiate_swap(&1, &buyer, &seller, &usdc_id, &500);
+
+        // Seller confirms with a decryption key
+        let key = Bytes::from_slice(&env, b"super-secret-key");
+        client.confirm_swap(&swap_id, &key);
+
+        // Key must be retrievable on-chain
+        let stored = client.get_decryption_key(&swap_id);
+        assert_eq!(stored, Some(key));
+
+        // USDC must have moved to seller
+        assert_eq!(usdc_client.balance(&seller), 500);
     }
 }


### PR DESCRIPTION
closes #6
- Swap struct gets a decryption_key: Option<Bytes> field (initialized to None on initiate_swap)
- confirm_swap stores the key into the struct before writing it back to storage
- New get_decryption_key(swap_id) getter lets the buyer query the key after confirmation
- test_decryption_key_accessible_after_confirmation spins up a real Stellar asset contract, runs a full initiate → confirm cycle, then asserts the stored key matches what 
the seller submitted and that USDC landed in the seller's account
