### PR TITLE
ci: add GitHub Actions workflow to build WASM artifacts and verify compilation (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
+
+      - name: Run tests
+        run: cargo test --workspace
+
+  build-wasm:
+    name: Build WASM Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable + wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm-
+
+      - name: Build WASM (all contracts)
+        run: cargo build --target wasm32-unknown-unknown --release --workspace
+
+      - name: Verify WASM artifacts exist
+        run: |
+          set -e
+          for contract in ip_registry atomic_swap zk_verifier; do
+            wasm="target/wasm32-unknown-unknown/release/${contract}.wasm"
+            if [ ! -f "$wasm" ]; then
+              echo "ERROR: Missing WASM artifact: $wasm"
+              exit 1
+            fi
+            echo "OK: $wasm ($(du -sh $wasm | cut -f1))"
+          done
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-artifacts
+          path: target/wasm32-unknown-unknown/release/*.wasm
+          if-no-files-found: error


### PR DESCRIPTION

Closes #46 

Adds a CI pipeline that builds all contracts to WASM and fails if any contract produces no deployable binary — catching cases where `cargo test` passes but the WASM build breaks.

## Changes
- New `.github/workflows/ci.yml` with two jobs:
  - `test`: runs `cargo test --workspace` on every push and PR
  - `build-wasm`: compiles all contracts with `--target wasm32-unknown-unknown --release`, asserts each `.wasm` artifact exists, and uploads them for inspection

## Why
A contract can pass unit tests but fail to produce a valid WASM binary (e.g. due to unsupported std features, missing target config, etc.). This workflow catches that gap in CI before anything reaches testnet.

## Testing
CI will self-validate on this PR. WASM artifacts are uploaded under the `wasm-artifacts` action artifact for manual inspection.