### PR TITLE
implemented build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,26 @@ Soroban smart contracts for atomic IP swaps using USDC, IP registry, and ZK veri
 See [contracts/](/contracts/) for sources.
 
 ## Build & Test
+
+Build all contracts:
 ```bash
 ./scripts/build.sh
+```
+
+Build a specific contract:
+```bash
+./scripts/build.sh <contract_name>
+```
+
+Available contracts: `ip_registry`, `atomic_swap`, `zk_verifier`
+
+Example:
+```bash
+./scripts/build.sh atomic_swap
+```
+
+Run tests:
+```bash
 ./scripts/test.sh
 ```
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,49 @@
 #!/usr/bin/env bash
 set -e
-cargo build --target wasm32-unknown-unknown --release
-echo "Build complete."
+
+# Available contracts in the workspace
+CONTRACTS=("ip_registry" "atomic_swap" "zk_verifier")
+
+# Build all contracts by default
+TARGET="${1:-all}"
+
+# Function to build a specific contract
+build_contract() {
+    local contract="$1"
+    local path="contracts/${contract}"
+    
+    if [ ! -d "$path" ]; then
+        echo "Error: Contract '${contract}' not found in workspace."
+        exit 1
+    fi
+    
+    echo "Building ${contract}..."
+    cargo build --target wasm32-unknown-unknown --release -p "${contract}"
+    echo "${contract} build complete."
+}
+
+# Validate target contract if not "all"
+if [ "$TARGET" != "all" ]; then
+    valid=false
+    for contract in "${CONTRACTS[@]}"; do
+        if [ "$TARGET" == "$contract" ]; then
+            valid=true
+            break
+        fi
+    done
+    
+    if [ "$valid" == "false" ]; then
+        echo "Error: Unknown contract '${TARGET}'"
+        echo "Available contracts: ${CONTRACTS[*]}"
+        exit 1
+    fi
+fi
+
+# Build contracts
+if [ "$TARGET" == "all" ]; then
+    echo "Building all contracts..."
+    cargo build --target wasm32-unknown-unknown --release
+    echo "All contracts built successfully."
+else
+    build_contract "$TARGET"
+fi


### PR DESCRIPTION
🚀 PR: Add Per-Contract Build Support (Closes #22)
📌 Summary

Updates build.sh to allow building individual contracts instead of the entire workspace.

✅ What was added
Optional contract name argument (./build.sh <contract>)
Fallback to full workspace build if no argument is provided
Updated README with new usage
🔁 Usage
./scripts/build.sh my-contract   # build single contract
./scripts/build.sh               # build all (default)
🎯 Result
Faster local development
More granular CI builds
Better developer experience

Closes #22