### PR TITLE
feat: add Makefile with build, test, deploy-testnet, and deploy-mainnet targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build test deploy-testnet deploy-mainnet
+
+build:
+	@bash scripts/build.sh
+
+test:
+	@bash scripts/test.sh
+
+deploy-testnet:
+	@bash scripts/deploy_testnet.sh
+
+deploy-mainnet:
+	@echo "WARNING: You are about to deploy to MAINNET."
+	@echo "This action is irreversible. Type 'yes' to continue:"
+	@read confirm && [ "$$confirm" = "yes" ] || (echo "Aborted." && exit 1)
+	@STELLAR_NETWORK=mainnet bash scripts/deploy_testnet.sh


### PR DESCRIPTION

Closes #48 

## Summary
Adds a Makefile as a single entry point for common developer tasks, removing the need to remember script paths or raw cargo commands.

## Changes
- `make build` — runs `scripts/build.sh`
- `make test` — runs `scripts/test.sh`
- `make deploy-testnet` — runs `scripts/deploy_testnet.sh`
- `make deploy-mainnet` — prompts for confirmation before deploying to mainnet

## Testing
Verified each target invokes the correct underlying script.