### PR TITLE
feat: add MyListingsDashboard for seller IP listings and pending swaps

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -45,6 +45,9 @@
         <!-- My Swaps Dashboard (React) -->
         <div id="dashboard-root"></div>
 
+        <!-- My Listings Dashboard (React) -->
+        <div id="listings-dashboard-root"></div>
+
         <!-- Key Reveal Section (existing) -->
         <section id="keyReveal">
             <h2>Reveal Decryption Key</h2>

--- a/frontend/src/components/ListingCard.css
+++ b/frontend/src/components/ListingCard.css
@@ -1,0 +1,113 @@
+/* ── ListingCard ─────────────────────────────────────────────────────────── */
+
+.lc {
+  background: #fff;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.lc__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.lc__id {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #1a202c;
+}
+
+.lc__price {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #6c63ff;
+  background: #f0eeff;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+}
+
+.lc__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+}
+
+.lc__label {
+  color: #718096;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.lc__hash {
+  font-family: monospace;
+  color: #4a5568;
+  word-break: break-all;
+  text-decoration: none;
+}
+
+.lc__hash:hover {
+  color: #6c63ff;
+  text-decoration: underline;
+}
+
+.lc__hash--empty {
+  color: #a0aec0;
+}
+
+.lc__no-swaps {
+  font-size: 0.82rem;
+  color: #a0aec0;
+  margin: 0;
+}
+
+.lc__swaps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.lc__swaps-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #718096;
+}
+
+.lc__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  background: #6c63ff;
+  color: #fff;
+}
+
+.lc__swaps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.lc__swap-item {
+  border-top: 1px solid #f0f0f0;
+  padding-top: 0.5rem;
+}

--- a/frontend/src/components/ListingCard.jsx
+++ b/frontend/src/components/ListingCard.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { ConfirmSwapForm } from "./ConfirmSwapForm";
+import "./ListingCard.css";
+
+const IPFS_GATEWAY =
+  import.meta.env.VITE_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs";
+
+/**
+ * ListingCard
+ *
+ * Displays a single IP listing owned by the connected seller, including
+ * any pending swaps that require confirmation.
+ *
+ * Props:
+ *   listing  - { id, ipfs_hash, price_usdc, pendingSwaps: Swap[] }
+ *   wallet   - connected wallet { address, signTransaction }
+ *   onUpdated - callback to refresh data after a swap action
+ */
+export function ListingCard({ listing, wallet, onUpdated }) {
+  const ipfsUrl = listing.ipfs_hash
+    ? `${IPFS_GATEWAY}/${listing.ipfs_hash}`
+    : null;
+
+  return (
+    <article className="lc" aria-label={`Listing #${listing.id}`}>
+      <div className="lc__header">
+        <span className="lc__id">Listing #{listing.id}</span>
+        {listing.price_usdc > 0 && (
+          <span className="lc__price">{listing.price_usdc / 1_000_000} USDC</span>
+        )}
+      </div>
+
+      <div className="lc__meta">
+        <span className="lc__label">IPFS Hash</span>
+        {ipfsUrl ? (
+          <a
+            className="lc__hash"
+            href={ipfsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={listing.ipfs_hash}
+          >
+            {listing.ipfs_hash.slice(0, 20)}…
+          </a>
+        ) : (
+          <span className="lc__hash lc__hash--empty">—</span>
+        )}
+      </div>
+
+      {listing.pendingSwaps.length === 0 ? (
+        <p className="lc__no-swaps">No pending swaps</p>
+      ) : (
+        <div className="lc__swaps">
+          <span className="lc__swaps-label">
+            Pending swaps
+            <span className="lc__badge">{listing.pendingSwaps.length}</span>
+          </span>
+          <ul className="lc__swaps-list">
+            {listing.pendingSwaps.map((swap) => (
+              <li key={swap.id} className="lc__swap-item">
+                <ConfirmSwapForm
+                  swap={swap}
+                  wallet={wallet}
+                  onSuccess={onUpdated}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/components/MyListingsDashboard.css
+++ b/frontend/src/components/MyListingsDashboard.css
@@ -1,0 +1,148 @@
+/* ── MyListingsDashboard ─────────────────────────────────────────────────── */
+
+.mld {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.mld__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+  gap: 0.75rem;
+}
+
+.mld__title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #1a202c;
+  margin: 0;
+}
+
+.mld__refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border: 1.5px solid #cbd5e0;
+  border-radius: 6px;
+  background: #fff;
+  color: #4a5568;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.mld__refresh-btn:hover:not(:disabled) {
+  border-color: #6c63ff;
+  color: #6c63ff;
+}
+
+.mld__refresh-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.mld__spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid #cbd5e0;
+  border-top-color: #6c63ff;
+  border-radius: 50%;
+  animation: mld-spin 0.6s linear infinite;
+}
+
+@keyframes mld-spin {
+  to { transform: rotate(360deg); }
+}
+
+.mld__error {
+  padding: 0.65rem 0.9rem;
+  background: #fff0f0;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #b91c1c;
+  margin-bottom: 1rem;
+}
+
+.mld__group {
+  margin-bottom: 1.5rem;
+}
+
+.mld__group-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #718096;
+  margin: 0 0 0.75rem;
+}
+
+.mld__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  background: #6c63ff;
+  color: #fff;
+}
+
+.mld__badge--muted {
+  background: #e2e8f0;
+  color: #718096;
+}
+
+.mld__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mld__skeleton {
+  height: 100px;
+  border-radius: 10px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e8e8e8 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: mld-shimmer 1.4s infinite;
+}
+
+@keyframes mld-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.mld__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1rem;
+  color: #a0aec0;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.mld__empty--disconnected {
+  color: #718096;
+}
+
+.mld__empty-icon {
+  font-size: 2rem;
+  line-height: 1;
+}

--- a/frontend/src/components/MyListingsDashboard.jsx
+++ b/frontend/src/components/MyListingsDashboard.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { useWallet } from "../context/WalletContext";
+import { useMyListings } from "../hooks/useMyListings";
+import { ListingCard } from "./ListingCard";
+import "./MyListingsDashboard.css";
+
+/**
+ * MyListingsDashboard
+ *
+ * Seller-facing page that shows all IP listings registered by the connected
+ * wallet, along with any pending swaps that require confirmation.
+ *
+ * Polls every 15 s and exposes a manual refresh button.
+ */
+export function MyListingsDashboard() {
+  const { wallet } = useWallet();
+  const { listings, loading, error, refresh } = useMyListings(
+    wallet?.address ?? null
+  );
+
+  if (!wallet) {
+    return (
+      <section className="mld" aria-label="My Listings Dashboard">
+        <div className="mld__empty mld__empty--disconnected">
+          <span className="mld__empty-icon" aria-hidden="true">🔌</span>
+          <p>Connect your wallet to view your listings.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const withPending = listings.filter((l) => l.pendingSwaps.length > 0);
+  const withoutPending = listings.filter((l) => l.pendingSwaps.length === 0);
+
+  return (
+    <section className="mld" aria-label="My Listings Dashboard">
+      <div className="mld__header">
+        <h2 className="mld__title">My Listings</h2>
+        <button
+          className="mld__refresh-btn"
+          onClick={refresh}
+          disabled={loading}
+          aria-label="Refresh listings"
+          aria-busy={loading}
+        >
+          {loading ? (
+            <span className="mld__spinner" aria-hidden="true" />
+          ) : (
+            <span aria-hidden="true">↻</span>
+          )}
+          {loading ? "Loading…" : "Refresh"}
+        </button>
+      </div>
+
+      {error && (
+        <p className="mld__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Skeleton while loading for the first time */}
+      {loading && listings.length === 0 && (
+        <ul className="mld__list" aria-label="Loading listings">
+          {[1, 2, 3].map((n) => (
+            <li key={n} className="mld__skeleton" aria-hidden="true" />
+          ))}
+        </ul>
+      )}
+
+      {/* Empty state */}
+      {!loading && listings.length === 0 && !error && (
+        <div className="mld__empty">
+          <span className="mld__empty-icon" aria-hidden="true">📂</span>
+          <p>No listings found for this wallet.</p>
+        </div>
+      )}
+
+      {/* Listings with pending swaps first */}
+      {withPending.length > 0 && (
+        <div className="mld__group">
+          <h3 className="mld__group-title">
+            Action Required
+            <span className="mld__badge">{withPending.length}</span>
+          </h3>
+          <ul className="mld__list">
+            {withPending.map((listing) => (
+              <li key={listing.id}>
+                <ListingCard
+                  listing={listing}
+                  wallet={wallet}
+                  onUpdated={refresh}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Listings without pending swaps */}
+      {withoutPending.length > 0 && (
+        <div className="mld__group">
+          <h3 className="mld__group-title">
+            All Listings
+            <span className="mld__badge mld__badge--muted">
+              {withoutPending.length}
+            </span>
+          </h3>
+          <ul className="mld__list">
+            {withoutPending.map((listing) => (
+              <li key={listing.id}>
+                <ListingCard
+                  listing={listing}
+                  wallet={wallet}
+                  onUpdated={refresh}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useMyListings.js
+++ b/frontend/src/hooks/useMyListings.js
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  getListingsByOwner,
+  getListing,
+  getSwapsBySeller,
+  getSwap,
+} from "../lib/contractClient";
+
+const POLL_INTERVAL_MS = 15_000;
+
+/**
+ * useMyListings
+ *
+ * Fetches all IP listings owned by the connected wallet, along with any
+ * pending swaps against each listing.
+ *
+ * @param {string|null} ownerAddress - Stellar public key, or null when disconnected
+ * @returns {{
+ *   listings: object[],   // each listing has a `pendingSwaps` array attached
+ *   loading: boolean,
+ *   error: string|null,
+ *   refresh: () => void,
+ * }}
+ */
+export function useMyListings(ownerAddress) {
+  const [listings, setListings] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const timerRef = useRef(null);
+
+  const fetchListings = useCallback(async () => {
+    if (!ownerAddress) {
+      setListings([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Fetch listing IDs and all seller swap IDs in parallel
+      const [listingIds, sellerSwapIds] = await Promise.all([
+        getListingsByOwner(ownerAddress),
+        getSwapsBySeller(ownerAddress).catch(() => []),
+      ]);
+
+      if (listingIds.length === 0) {
+        setListings([]);
+        return;
+      }
+
+      // Fetch listing details and all seller swaps in parallel
+      const [listingResults, swapResults] = await Promise.all([
+        Promise.allSettled(listingIds.map((id) => getListing(id))),
+        Promise.allSettled(sellerSwapIds.map((id) => getSwap(id))),
+      ]);
+
+      const loadedListings = listingResults
+        .filter((r) => r.status === "fulfilled" && r.value !== null)
+        .map((r) => r.value);
+
+      const allSellerSwaps = swapResults
+        .filter((r) => r.status === "fulfilled" && r.value !== null)
+        .map((r) => r.value)
+        .filter((s) => s.status === "Pending");
+
+      // Attach pending swaps to their respective listing
+      const enriched = loadedListings.map((listing) => ({
+        ...listing,
+        pendingSwaps: allSellerSwaps.filter(
+          (s) => s.listing_id === listing.id
+        ),
+      }));
+
+      setListings(enriched);
+    } catch (err) {
+      setError(err.message || "Failed to load listings.");
+    } finally {
+      setLoading(false);
+    }
+  }, [ownerAddress]);
+
+  useEffect(() => {
+    fetchListings();
+    timerRef.current = setInterval(fetchListings, POLL_INTERVAL_MS);
+    return () => clearInterval(timerRef.current);
+  }, [fetchListings]);
+
+  return { listings, loading, error, refresh: fetchListings };
+}

--- a/frontend/src/lib/contractClient.ts
+++ b/frontend/src/lib/contractClient.ts
@@ -5,6 +5,7 @@ const RPC_URL =
   "https://soroban-testnet.stellar.org";
 
 const ATOMIC_SWAP_CONTRACT_ID = import.meta.env.VITE_CONTRACT_ATOMIC_SWAP;
+const IP_REGISTRY_CONTRACT_ID = import.meta.env.VITE_CONTRACT_IP_REGISTRY;
 
 const networkPassphrase = () =>
   import.meta.env.VITE_STELLAR_NETWORK === "mainnet"
@@ -254,4 +255,115 @@ async function submitAndPoll(
   if (txResponse.status !== "SUCCESS") {
     throw new Error(`Transaction did not succeed: ${txResponse.status}`);
   }
+}
+
+// ─── IP Registry ──────────────────────────────────────────────────────────────
+
+/**
+ * Simulate a read-only call against the ip_registry contract.
+ */
+async function simulateIpRegistryView(functionName, args) {
+  if (!IP_REGISTRY_CONTRACT_ID) {
+    throw new Error("VITE_CONTRACT_IP_REGISTRY is not configured.");
+  }
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const keypair = StellarSdk.Keypair.random();
+  const account = new StellarSdk.Account(keypair.publicKey(), "0");
+  const contract = new StellarSdk.Contract(IP_REGISTRY_CONTRACT_ID);
+
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(contract.call(functionName, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+
+  if (StellarSdk.SorobanRpc.Api.isSimulationError(result)) {
+    throw new Error(`Simulation failed: ${result.error}`);
+  }
+
+  return result.result?.retval;
+}
+
+/**
+ * Decode a Listing ScVal into a plain JS object.
+ * Listing { owner, ipfs_hash, merkle_root, royalty_bps, royalty_recipient, price_usdc }
+ */
+function decodeListingScVal(scVal, listingId) {
+  if (!scVal || scVal.switch().name === "scvVoid") return null;
+
+  const native = StellarSdk.scValToNative(scVal);
+  if (!native || typeof native !== "object") return null;
+
+  // ipfs_hash and merkle_root are Bytes — scValToNative returns Buffer/Uint8Array
+  const toHex = (v) =>
+    v instanceof Uint8Array || Buffer.isBuffer(v)
+      ? Buffer.from(v).toString("hex")
+      : String(v ?? "");
+
+  return {
+    id: listingId,
+    owner: String(native.owner ?? ""),
+    ipfs_hash: toHex(native.ipfs_hash),
+    merkle_root: toHex(native.merkle_root),
+    royalty_bps: Number(native.royalty_bps ?? 0),
+    royalty_recipient: String(native.royalty_recipient ?? ""),
+    price_usdc: Number(native.price_usdc ?? 0),
+  };
+}
+
+/**
+ * Fetch all listing IDs owned by the given address.
+ * @param {string} ownerAddress - Stellar public key (G...)
+ * @returns {Promise<number[]>}
+ */
+export async function getListingsByOwner(ownerAddress) {
+  const addressScVal = StellarSdk.nativeToScVal(
+    new StellarSdk.Address(ownerAddress),
+    { type: "address" }
+  );
+
+  const retval = await simulateIpRegistryView("list_by_owner", [addressScVal]);
+  if (!retval) return [];
+
+  const arr = StellarSdk.scValToNative(retval);
+  if (!Array.isArray(arr)) return [];
+  return arr.map((v) => Number(v));
+}
+
+/**
+ * Fetch full listing details for a single listing ID.
+ * @param {number} listingId
+ * @returns {Promise<object|null>}
+ */
+export async function getListing(listingId) {
+  const retval = await simulateIpRegistryView("get_listing", [
+    StellarSdk.nativeToScVal(listingId, { type: "u64" }),
+  ]);
+
+  if (!retval) return null;
+  return decodeListingScVal(retval, listingId);
+}
+
+/**
+ * Fetch all swap IDs for a seller by calling get_swaps_by_seller.
+ * @param {string} sellerAddress - Stellar public key (G...)
+ * @returns {Promise<number[]>}
+ */
+export async function getSwapsBySeller(sellerAddress) {
+  const addressScVal = StellarSdk.nativeToScVal(
+    new StellarSdk.Address(sellerAddress),
+    { type: "address" }
+  );
+
+  const retval = await simulateView("get_swaps_by_seller", [addressScVal]);
+  if (!retval) return [];
+
+  const arr = StellarSdk.scValToNative(retval);
+  if (!Array.isArray(arr)) return [];
+  return arr.map((v) => Number(v));
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,15 +4,19 @@ import { createRoot } from "react-dom/client";
 import { WalletProvider } from "./context/WalletContext";
 import { WalletConnectButton } from "./components/WalletConnectButton";
 import { MySwapsDashboard } from "./components/MySwapsDashboard";
+import { MyListingsDashboard } from "./components/MyListingsDashboard";
+
 
 function App() {
   const walletRoot = document.getElementById("wallet-root");
   const dashboardRoot = document.getElementById("dashboard-root");
+  const listingsRoot = document.getElementById("listings-dashboard-root");
 
   return (
     <WalletProvider>
       {walletRoot && createPortal(<WalletConnectButton />, walletRoot)}
       {dashboardRoot && createPortal(<MySwapsDashboard />, dashboardRoot)}
+      {listingsRoot && createPortal(<MyListingsDashboard />, listingsRoot)}
     </WalletProvider>
   );
 }


### PR DESCRIPTION
Adds a seller-facing dashboard that shows all registered IP listings for the connected wallet, with pending swaps surfaced inline for one-click confirmation.

- contractClient.js: add getListingsByOwner, getListing, getSwapsBySeller backed by ip_registry and atomic_swap Soroban view calls
- useMyListings hook: fetches listings + attaches pending seller swaps, polls every 15s
- ListingCard component: displays IPFS hash, listing ID, price, and ConfirmSwapForm for each pending swap
- MyListingsDashboard component: groups listings by action-required vs idle, skeleton loading, empty/disconnected states
- index.html + main.jsx: mount listings-dashboard-root portal


close #93