### PR TITLE
Add test for zero amount validation in initiate_swap (#103)

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -753,6 +753,29 @@ mod test {
     // ── price enforcement tests ───────────────────────────────────────────────
 
     #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn test_initiate_swap_rejects_zero_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let zk_verifier = Address::generate(&env);
+        let (usdc_id, listing_id, registry_id, _cid, client, _admin) =
+            setup_full(&env, &buyer, &seller, 1000, 0);
+
+        client.initiate_swap(
+            &listing_id,
+            &buyer,
+            &seller,
+            &usdc_id,
+            &0,
+            &zk_verifier,
+            &registry_id,
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "Error(Contract, #14)")]
     fn test_initiate_swap_rejects_underpayment() {
         let env = Env::default();


### PR DESCRIPTION
Description
This PR addresses issue #103  by adding a test to verify that initiate_swap properly validates that usdc_amount is positive using structured error handling.

Changes Made
Added test_initiate_swap_rejects_zero_amount test function in contracts/atomic_swap/src/lib.rs
The test verifies that calling initiate_swap with usdc_amount = 0 properly rejects with error code #3 (ContractError::InvalidAmount)
The existing code at lines 256-257 already uses the correct panic_with_error! pattern for machine-readable error formatting

closes #103 