### PR TITLE
fix(scripts): improve test.sh with --locked, --workspace, --nocapture…

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
+# Run all contract tests with Cargo.lock enforcement and verbose CI output.
 set -euo pipefail
 
-echo "Running all contract tests..."
-cargo test --locked --workspace -- --nocapture
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+echo "================================================================"
+echo "Running contract tests"
+echo "  --locked     : Cargo.lock must be up to date"
+echo "  --workspace  : All contracts in the workspace"
+echo "  --nocapture  : Full output for CI logs"
+echo "================================================================"
+
+cargo test \
+  --locked \
+  --workspace \
+  --manifest-path "${ROOT_DIR}/Cargo.toml" \
+  -- \
+  --nocapture
+
+echo ""
 echo "All tests passed."


### PR DESCRIPTION
… flags

- Explicitly pass --manifest-path for reliable CI execution from any directory
- Add descriptive header logging each flag and its purpose
- Satisfies: cargo test --locked --workspace -- --nocapture
Closes #144 