### PR TITLE
feat: confirm swap flow for sellers

### DIFF
--- a/frontend/src/components/ConfirmSwapForm.css
+++ b/frontend/src/components/ConfirmSwapForm.css
@@ -92,3 +92,14 @@
   color: #e53e3e;
   margin: 0;
 }
+
+/* Updated balance after confirmation */
+.confirm-swap-form__balance {
+  font-size: 13px;
+  color: #276749;
+  background: #f0fff4;
+  border: 1px solid #9ae6b4;
+  border-radius: 6px;
+  padding: 6px 10px;
+  margin: 0;
+}

--- a/frontend/src/components/ConfirmSwapForm.tsx
+++ b/frontend/src/components/ConfirmSwapForm.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
-import { confirmSwap } from "../lib/contractClient";
+import { confirmSwap, getUsdcBalance } from "../lib/contractClient";
 import type { Wallet } from "../lib/walletKit";
 import type { Swap } from "../hooks/useMySwaps";
 import "./ConfirmSwapForm.css";
+
+const USDC_DECIMALS = 7;
 
 interface Props {
   swap: Swap;
@@ -14,17 +16,22 @@ export function ConfirmSwapForm({ swap, wallet, onSuccess }: Props) {
   const [decryptionKey, setDecryptionKey] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [newBalance, setNewBalance] = useState<number | null>(null);
 
   if (swap.status !== "Pending") return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setNewBalance(null);
     if (!decryptionKey.trim()) { setError("Decryption key cannot be empty."); return; }
     setLoading(true);
     try {
       await confirmSwap(swap.id, decryptionKey.trim(), wallet);
       setDecryptionKey("");
+      // Fetch updated balance after confirmation
+      const balance = await getUsdcBalance(wallet.address).catch(() => null);
+      setNewBalance(balance);
       onSuccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to confirm swap.");
@@ -33,11 +40,13 @@ export function ConfirmSwapForm({ swap, wallet, onSuccess }: Props) {
     }
   };
 
+  const displayAmount = (swap.usdc_amount / Math.pow(10, USDC_DECIMALS)).toFixed(2);
+
   return (
     <form className="confirm-swap-form" onSubmit={handleSubmit} noValidate>
       <div className="confirm-swap-form__meta">
         <span>Swap #{swap.id}</span>
-        <span>{swap.usdc_amount} USDC</span>
+        <span>{displayAmount} USDC</span>
       </div>
       <label className="confirm-swap-form__label" htmlFor={`dk-${swap.id}`}>Decryption Key</label>
       <input
@@ -52,6 +61,11 @@ export function ConfirmSwapForm({ swap, wallet, onSuccess }: Props) {
         spellCheck={false}
       />
       {error && <p className="confirm-swap-form__error" role="alert">{error}</p>}
+      {newBalance !== null && (
+        <p className="confirm-swap-form__balance" role="status">
+          USDC balance: {newBalance.toFixed(2)}
+        </p>
+      )}
       <button
         className="confirm-swap-form__btn"
         type="submit"

--- a/frontend/src/hooks/useMySwaps.ts
+++ b/frontend/src/hooks/useMySwaps.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { getSwapsByBuyer, getSwap, getLedgerTimestamp } from "../lib/contractClient";
+import { getSwapsByBuyer, getSwapsBySeller, getSwap, getLedgerTimestamp } from "../lib/contractClient";
 
 const POLL_INTERVAL_MS = 15_000;
 
@@ -15,7 +15,7 @@ export interface Swap {
   decryption_key: string | null;
 }
 
-export function useMySwaps(buyerAddress: string | null) {
+export function useMySwaps(walletAddress: string | null) {
   const [swaps, setSwaps] = useState<Swap[]>([]);
   const [ledgerTimestamp, setLedgerTimestamp] = useState<number>(
     () => Math.floor(Date.now() / 1000)
@@ -25,17 +25,20 @@ export function useMySwaps(buyerAddress: string | null) {
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchSwaps = useCallback(async () => {
-    if (!buyerAddress) { setSwaps([]); return; }
+    if (!walletAddress) { setSwaps([]); return; }
     setLoading(true);
     setError(null);
     try {
-      const [ids, ts] = await Promise.all([
-        getSwapsByBuyer(buyerAddress),
+      const [buyerIds, sellerIds, ts] = await Promise.all([
+        getSwapsByBuyer(walletAddress),
+        getSwapsBySeller(walletAddress).catch(() => [] as number[]),
         getLedgerTimestamp(),
       ]);
       setLedgerTimestamp(ts);
-      if (ids.length === 0) { setSwaps([]); return; }
-      const results = await Promise.allSettled(ids.map((id) => getSwap(id)));
+      // Deduplicate IDs (a wallet could theoretically be both buyer and seller)
+      const allIds = [...new Set([...buyerIds, ...sellerIds])];
+      if (allIds.length === 0) { setSwaps([]); return; }
+      const results = await Promise.allSettled(allIds.map((id) => getSwap(id)));
       const loaded = results
         .filter((r): r is PromiseFulfilledResult<Swap> => r.status === "fulfilled" && r.value !== null)
         .map((r) => r.value);
@@ -45,7 +48,7 @@ export function useMySwaps(buyerAddress: string | null) {
     } finally {
       setLoading(false);
     }
-  }, [buyerAddress]);
+  }, [walletAddress]);
 
   useEffect(() => {
     fetchSwaps();

--- a/frontend/src/lib/contractClient.ts
+++ b/frontend/src/lib/contractClient.ts
@@ -338,3 +338,45 @@ export async function getSwapsBySeller(sellerAddress) {
   if (!Array.isArray(arr)) return [];
   return arr.map((v) => Number(v));
 }
+
+// ─── USDC Balance ─────────────────────────────────────────────────────────────
+
+const USDC_CONTRACT_ID = import.meta.env.VITE_CONTRACT_USDC ?? "";
+const USDC_DECIMALS = 7;
+
+/**
+ * Fetch the USDC balance for a given address by calling `balance(address)`
+ * on the USDC token contract.
+ * @param {string} address - Stellar public key (G...)
+ * @returns {Promise<number>} - Balance in human-readable USDC (e.g. 12.5)
+ */
+export async function getUsdcBalance(address: string): Promise<number> {
+  if (!USDC_CONTRACT_ID) return 0;
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const keypair = StellarSdk.Keypair.random();
+  const account = new StellarSdk.Account(keypair.publicKey(), "0");
+  const contract = new StellarSdk.Contract(USDC_CONTRACT_ID);
+
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "balance",
+        StellarSdk.nativeToScVal(new StellarSdk.Address(address), { type: "address" })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+  if (StellarSdk.SorobanRpc.Api.isSimulationError(result)) return 0;
+
+  const retval = result.result?.retval;
+  if (!retval) return 0;
+
+  const raw = StellarSdk.scValToNative(retval);
+  return Number(raw) / Math.pow(10, USDC_DECIMALS);
+}


### PR DESCRIPTION
Closes #127

---

useMySwaps was only fetching swaps where the wallet is the buyer, so sellers couldn't see their pending swaps in the dashboard. Fixed it to fetch both buyer and seller swaps and merge them.

Nothing was showing the USDC balance after a confirmation. Added getUsdcBalance() to the contract client and wired it into ConfirmSwapForm so it displays the updated balance after a successful confirm.
