### PR TITLE
feat: add get_swaps_by_buyer_page with pagination support (#118)

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -31,6 +31,8 @@ pub enum ContractError {
     FeeWouldTruncate = 15,
     /// ZK Merkle proof verification failed.
     InvalidProof = 16,
+    /// Pagination offset or limit is out of valid range.
+    InvalidPaginationParams = 17,
 }
 
 #[contracttype]
@@ -638,6 +640,35 @@ impl AtomicSwap {
             .persistent()
             .get(&DataKey::BuyerIndex(buyer))
             .unwrap_or_else(|| soroban_sdk::Vec::new(&env))
+    }
+
+    /// Paginated variant of `get_swaps_by_buyer`.
+    /// Returns up to `limit` swap IDs starting at `offset`.
+    /// Panics with `InvalidPaginationParams` if `limit` is 0 or `offset` exceeds the list length.
+    pub fn get_swaps_by_buyer_page(
+        env: Env,
+        buyer: Address,
+        offset: u32,
+        limit: u32,
+    ) -> soroban_sdk::Vec<u64> {
+        if limit == 0 {
+            panic_with_error!(&env, ContractError::InvalidPaginationParams);
+        }
+        let all: soroban_sdk::Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BuyerIndex(buyer))
+            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+        let total = all.len();
+        if offset > total {
+            panic_with_error!(&env, ContractError::InvalidPaginationParams);
+        }
+        let end = (offset + limit).min(total);
+        let mut page = soroban_sdk::Vec::new(&env);
+        for i in offset..end {
+            page.push_back(all.get(i).unwrap());
+        }
+        page
     }
 
     pub fn get_swaps_by_seller(env: Env, seller: Address) -> soroban_sdk::Vec<u64> {
@@ -1887,5 +1918,99 @@ mod test {
         client.cancel_swap(&swap_id);
 
         assert!(client.is_listing_available(&listing_id));
+    }
+
+    #[test]
+    fn test_get_swaps_by_buyer_page_empty_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+        let buyer = Address::generate(&env);
+        let page = client.get_swaps_by_buyer_page(&buyer, &0u32, &10u32);
+        assert_eq!(page.len(), 0);
+    }
+
+    #[test]
+    fn test_get_swaps_by_buyer_page_full_page() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id1, registry_id, _cid, client, _admin) =
+            setup_full(&env, &buyer, &seller, 1500, 0);
+        let listing_id2 = IpRegistryClient::new(&env, &registry_id).register_ip(
+            &seller,
+            &Bytes::from_slice(&env, b"h2"),
+            &Bytes::from_slice(&env, b"r2"),
+            &0u32,
+            &seller,
+            &0i128,
+        );
+        let listing_id3 = IpRegistryClient::new(&env, &registry_id).register_ip(
+            &seller,
+            &Bytes::from_slice(&env, b"h3"),
+            &Bytes::from_slice(&env, b"r3"),
+            &0u32,
+            &seller,
+            &0i128,
+        );
+        let id1 = pending_swap(&env, &client, listing_id1, &buyer, &seller, &usdc_id, &registry_id, 500);
+        let id2 = pending_swap(&env, &client, listing_id2, &buyer, &seller, &usdc_id, &registry_id, 500);
+        let id3 = pending_swap(&env, &client, listing_id3, &buyer, &seller, &usdc_id, &registry_id, 500);
+        // full page
+        let page = client.get_swaps_by_buyer_page(&buyer, &0u32, &3u32);
+        assert_eq!(page.len(), 3);
+        assert_eq!(page.get(0).unwrap(), id1);
+        assert_eq!(page.get(1).unwrap(), id2);
+        assert_eq!(page.get(2).unwrap(), id3);
+        // first page of 2
+        let page0 = client.get_swaps_by_buyer_page(&buyer, &0u32, &2u32);
+        assert_eq!(page0.len(), 2);
+        assert_eq!(page0.get(0).unwrap(), id1);
+        assert_eq!(page0.get(1).unwrap(), id2);
+        // second page (partial)
+        let page1 = client.get_swaps_by_buyer_page(&buyer, &2u32, &2u32);
+        assert_eq!(page1.len(), 1);
+        assert_eq!(page1.get(0).unwrap(), id3);
+    }
+
+    #[test]
+    fn test_get_swaps_by_buyer_page_offset_at_end() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, registry_id, _cid, client, _admin) =
+            setup_full(&env, &buyer, &seller, 500, 0);
+        pending_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, &registry_id, 500);
+        // offset == len returns empty page
+        let page = client.get_swaps_by_buyer_page(&buyer, &1u32, &10u32);
+        assert_eq!(page.len(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #17)")]
+    fn test_get_swaps_by_buyer_page_zero_limit_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+        let buyer = Address::generate(&env);
+        client.get_swaps_by_buyer_page(&buyer, &0u32, &0u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #17)")]
+    fn test_get_swaps_by_buyer_page_offset_out_of_bounds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, registry_id, _cid, client, _admin) =
+            setup_full(&env, &buyer, &seller, 500, 0);
+        pending_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, &registry_id, 500);
+        // offset=2 on a list of 1 should panic
+        client.get_swaps_by_buyer_page(&buyer, &2u32, &10u32);
     }
 }


### PR DESCRIPTION
- Add get_swaps_by_buyer_page(env, buyer, offset, limit) to AtomicSwap
- Add InvalidPaginationParams = 17 to ContractError for bounds violations
- Panics if limit == 0 or offset > list length; offset == len returns empty page
- Keep existing get_swaps_by_buyer unchanged for backward compatibility
- Add 5 tests: empty list, full page, partial page, offset-at-end, zero limit, out-of-bounds


Closes #118 