### PR TITLE
fix: add proof_path support to confirmSwap and ConfirmSwapForm (#331)

### DIFF
--- a/frontend/src/components/ConfirmSwapForm.tsx
+++ b/frontend/src/components/ConfirmSwapForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { confirmSwap, getUsdcBalance } from "../lib/contractClient";
+import type { ProofNode } from "../lib/contractClient";
 import type { Wallet } from "../lib/walletKit";
 import type { Swap } from "../hooks/useMySwaps";
 import "./ConfirmSwapForm.css";
@@ -12,8 +13,29 @@ interface Props {
   onSuccess: () => void;
 }
 
+function parseProofPath(raw: string): ProofNode[] {
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Proof path must be a JSON array.");
+  }
+  return parsed.map((node: any, i: number) => {
+    if (!node.sibling || typeof node.sibling !== "string") {
+      throw new Error(`ProofNode[${i}].sibling must be a hex string.`);
+    }
+    if (typeof node.is_left !== "boolean") {
+      throw new Error(`ProofNode[${i}].is_left must be a boolean.`);
+    }
+    const hex = node.sibling.replace(/^0x/, "");
+    if (hex.length !== 64) {
+      throw new Error(`ProofNode[${i}].sibling must be 64 hex chars (32 bytes), got ${hex.length}.`);
+    }
+    return { sibling: hex, is_left: node.is_left };
+  });
+}
+
 export function ConfirmSwapForm({ swap, wallet, onSuccess }: Props) {
   const [decryptionKey, setDecryptionKey] = useState("");
+  const [proofPath, setProofPath] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [newBalance, setNewBalance] = useState<number | null>(null);
@@ -25,10 +47,19 @@ export function ConfirmSwapForm({ swap, wallet, onSuccess }: Props) {
     setError(null);
     setNewBalance(null);
     if (!decryptionKey.trim()) { setError("Decryption key cannot be empty."); return; }
+    if (!proofPath.trim()) { setError("Proof path cannot be empty."); return; }
+    let parsedPath: ProofNode[];
+    try {
+      parsedPath = parseProofPath(proofPath.trim());
+    } catch (err) {
+      setError(err instanceof Error ? `Invalid proof path: ${err.message}` : "Invalid proof path.");
+      return;
+    }
     setLoading(true);
     try {
-      await confirmSwap(swap.id, decryptionKey.trim(), wallet);
+      await confirmSwap(swap.id, decryptionKey.trim(), parsedPath, wallet);
       setDecryptionKey("");
+      setProofPath("");
       // Fetch updated balance after confirmation
       const balance = await getUsdcBalance(wallet.address).catch(() => null);
       setNewBalance(balance);
@@ -60,6 +91,18 @@ export function ConfirmSwapForm({ swap, wallet, onSuccess }: Props) {
         autoComplete="off"
         spellCheck={false}
       />
+      <label className="confirm-swap-form__label" htmlFor={`pp-${swap.id}`}>Proof Path (JSON)</label>
+      <textarea
+        id={`pp-${swap.id}`}
+        className="confirm-swap-form__input confirm-swap-form__textarea"
+        placeholder='[{"sibling": "0x...64 hex chars...", "is_left": true}, ...]'
+        value={proofPath}
+        onChange={(e) => setProofPath(e.target.value)}
+        disabled={loading}
+        autoComplete="off"
+        spellCheck={false}
+        rows={3}
+      />
       {error && <p className="confirm-swap-form__error" role="alert">{error}</p>}
       {newBalance !== null && (
         <p className="confirm-swap-form__balance" role="status">
@@ -69,7 +112,7 @@ export function ConfirmSwapForm({ swap, wallet, onSuccess }: Props) {
       <button
         className="confirm-swap-form__btn"
         type="submit"
-        disabled={loading || !decryptionKey.trim()}
+        disabled={loading || !decryptionKey.trim() || !proofPath.trim()}
         aria-busy={loading}
       >
         {loading && <span className="confirm-swap-spinner" aria-hidden="true" />}

--- a/frontend/src/lib/contractClient.ts
+++ b/frontend/src/lib/contractClient.ts
@@ -183,14 +183,53 @@ export async function cancelSwap(
 }
 
 /**
- * Calls confirm_swap(swap_id, decryption_key) on the atomic_swap contract.
+ * Encode a ProofNode[] as a Soroban Vec<ProofNode> ScVal.
+ *
+ * Expected JSON format for each node:
+ *   { "sibling": "0x..." or hex string (32 bytes), "is_left": true|false }
+ */
+function encodeProofPath(proofPath: ProofNode[]): import("@stellar/stellar-sdk").xdr.ScVal {
+  return StellarSdk.xdr.ScVal.scvVec(
+    proofPath.map((node) => {
+      const siblingBytes = Buffer.from(node.sibling.replace(/^0x/, ""), "hex");
+      if (siblingBytes.length !== 32) {
+        throw new Error(`ProofNode sibling must be exactly 32 bytes (64 hex chars), got ${siblingBytes.length} bytes.`);
+      }
+      return StellarSdk.xdr.ScVal.scvMap([
+        new StellarSdk.xdr.ScMapEntry({
+          key: StellarSdk.xdr.ScVal.scvSymbol("is_left"),
+          val: StellarSdk.xdr.ScVal.scvBool(node.is_left),
+        }),
+        new StellarSdk.xdr.ScMapEntry({
+          key: StellarSdk.xdr.ScVal.scvSymbol("sibling"),
+          val: StellarSdk.xdr.ScVal.scvBytes(siblingBytes),
+        }),
+      ]);
+    }),
+  );
+}
+
+/**
+ * Calls confirm_swap(swap_id, decryption_key, proof_path) on the atomic_swap contract.
+ *
+ * proof_path format (JSON array):
+ *   [
+ *     { "sibling": "<64-char-hex>", "is_left": true },
+ *     { "sibling": "<64-char-hex>", "is_left": false },
+ *     ...
+ *   ]
+ *
+ * Each sibling must be exactly 32 bytes (64 hex characters).
+ *
  * @param {string|number} swapId
  * @param {string} decryptionKey - hex or base64 string of the decryption key
+ * @param {ProofNode[]} proofPath - Merkle proof path (Vec<ProofNode>)
  * @param {object} wallet        - { address, signTransaction }
  */
 export async function confirmSwap(
   swapId: number | string,
   decryptionKey: string,
+  proofPath: ProofNode[],
   wallet: {
     address: string;
     signTransaction: (xdr: string) => Promise<string>;
@@ -202,6 +241,9 @@ export async function confirmSwap(
   if (!decryptionKey || !decryptionKey.trim()) {
     throw new Error("Decryption key is required.");
   }
+  if (!proofPath || proofPath.length === 0) {
+    throw new Error("Proof path is required and must be non-empty.");
+  }
 
   const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
   const sourceAccount = await server.getAccount(wallet.address);
@@ -210,6 +252,8 @@ export async function confirmSwap(
   const keyBytes = StellarSdk.xdr.ScVal.scvBytes(
     Buffer.from(decryptionKey.replace(/^0x/, ""), "hex"),
   );
+
+  const proofPathScVal = encodeProofPath(proofPath);
 
   const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
     fee: StellarSdk.BASE_FEE,
@@ -220,6 +264,7 @@ export async function confirmSwap(
         "confirm_swap",
         StellarSdk.nativeToScVal(Number(swapId), { type: "u64" }),
         keyBytes,
+        proofPathScVal,
       ),
     )
     .setTimeout(30)
@@ -597,22 +642,7 @@ export async function verifyPartialProof(
 ): Promise<boolean> {
   const leafBytes = Buffer.from(leafHex.replace(/^0x/, ""), "hex");
 
-  // Build Vec<ProofNode> as ScVal
-  const pathScVal = StellarSdk.xdr.ScVal.scvVec(
-    path.map((node) => {
-      const siblingBytes = Buffer.from(node.sibling.replace(/^0x/, ""), "hex");
-      return StellarSdk.xdr.ScVal.scvMap([
-        new StellarSdk.xdr.ScMapEntry({
-          key: StellarSdk.xdr.ScVal.scvSymbol("is_left"),
-          val: StellarSdk.xdr.ScVal.scvBool(node.is_left),
-        }),
-        new StellarSdk.xdr.ScMapEntry({
-          key: StellarSdk.xdr.ScVal.scvSymbol("sibling"),
-          val: StellarSdk.xdr.ScVal.scvBytes(siblingBytes),
-        }),
-      ]);
-    })
-  );
+  const pathScVal = encodeProofPath(path);
 
   const retval = await simulateZkView("verify_partial_proof", [
     StellarSdk.nativeToScVal(listingId, { type: "u64" }),


### PR DESCRIPTION
Solution:

contractClient.ts — Added encodeProofPath() helper to serialize ProofNode[] to Soroban ScVal format, updated confirmSwap() to accept and pass proofPath: ProofNode[] as the 3rd argument to the contract call, added runtime validation that the proof path is non-empty, and documented the expected JSON format.
ConfirmSwapForm.tsx — Added a JSON textarea input for the proof path, added parseProofPath() to parse and validate the input (validates array shape, sibling is 64 hex chars, is_left is boolean), added client-side non-empty validation, and disabled the submit button when proof path is empty.

Closes #331 