### PR TITLE
feat: add get_owner view function to zk_verifier (#330)

### DIFF
--- a/contracts/zk_verifier/src/lib.rs
+++ b/contracts/zk_verifier/src/lib.rs
@@ -106,6 +106,13 @@ impl ZkVerifier {
             .get(&DataKey::MerkleRoot(listing_id))
     }
 
+    /// Retrieves the owner of a listing's Merkle root, or None if no root has been set.
+    pub fn get_owner(env: Env, listing_id: u64) -> Option<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Owner(listing_id))
+    }
+
     /// Verify a Merkle inclusion proof for a leaf against the stored root.
     ///
     /// # Proof format
@@ -193,6 +200,32 @@ mod test {
         let contract_id = env.register(ZkVerifier, ());
         let client = ZkVerifierClient::new(&env, &contract_id);
         assert_eq!(client.get_merkle_root(&99u64), None);
+    }
+
+    #[test]
+    fn test_get_owner_returns_none_when_no_root() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ZkVerifier, ());
+        let client = ZkVerifierClient::new(&env, &contract_id);
+        assert_eq!(client.get_owner(&99u64), None);
+    }
+
+    #[test]
+    fn test_get_owner_returns_correct_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ZkVerifier, ());
+        let client = ZkVerifierClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let root: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(&env, b"root"))
+            .into();
+        client.set_merkle_root(&owner, &1u64, &root);
+
+        assert_eq!(client.get_owner(&1u64), Some(owner));
     }
 
     #[test]


### PR DESCRIPTION
Issue #330 — zk_verifier has no get_owner view function
Problem: There was no public function to query who owns the Merkle root for a given listing. Frontends and other contracts had to call set_merkle_root and catch the unauthorized error to infer ownership — wasteful and error-prone.

Solution:

contracts/zk_verifier/src/lib.rs — Added get_owner(env, listing_id) -> Option<Address> view function that reads from DataKey::Owner(listing_id) persistent storage. Returns Some(owner) if a root has been set, None otherwise.
Tests added:
test_get_owner_returns_none_when_no_root — asserts None is returned for a listing ID with no root set
test_get_owner_returns_correct_owner — asserts the correct owner address is returned after set_merkle_root is called
Branch: fix/issue-330-zk-verifier-get-owner Files changed: 1 (contracts/zk_verifier/src/lib.rs) Lines: +33 Category: Smart Contract - Enhancement (Rust/Soroban)
close #330 