### PR TITLE
fix(ip_registry): validate price > 0 in register_ip (#260)

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -253,8 +253,7 @@ impl IpRegistry {
         price_usdc: i128,
     ) -> Result<u64, ContractError> {
         assert_not_paused(&env);
-        if ipfs_hash.is_empty() || merkle_root.is_empty() || price_usdc < 0 || royalty_bps > 10_000
-        {
+        if ipfs_hash.is_empty() || merkle_root.is_empty() || royalty_bps > 10_000 {
             return Err(ContractError::InvalidInput);
         }
         if price_usdc <= 0 {
@@ -728,15 +727,12 @@ mod test {
             &owner,
             &-1i128,
         );
-        assert_eq!(result, Err(Ok(ContractError::InvalidInput)));
+        assert_eq!(result, Err(Ok(ContractError::InvalidPrice)));
     }
 
     #[test]
     fn test_register_rejects_zero_price() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(IpRegistry, ());
-        let client = IpRegistryClient::new(&env, &contract_id);
+        let (env, client, _admin) = setup();
         let owner = Address::generate(&env);
         let result = client.try_register_ip(
             &owner,
@@ -1150,5 +1146,46 @@ mod test {
 
         // value contains the non-topic fields
         assert_eq!(event.2, Bytes::from_slice(&env, hash).into_val(&env));
+    }
+
+    // ── Issue #260 tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_register_ip_zero_price() {
+        let (env, client, _admin) = setup();
+        let owner = Address::generate(&env);
+        let result = client.try_register_ip(
+            &owner,
+            &Bytes::from_slice(&env, b"QmHash"),
+            &Bytes::from_slice(&env, b"root"),
+            &0u32,
+            &owner,
+            &0i128,
+        );
+        assert_eq!(result, Err(Ok(ContractError::InvalidPrice)));
+    }
+
+    #[test]
+    fn test_register_ip_negative_price() {
+        let (env, client, _admin) = setup();
+        let owner = Address::generate(&env);
+        let result = client.try_register_ip(
+            &owner,
+            &Bytes::from_slice(&env, b"QmHash"),
+            &Bytes::from_slice(&env, b"root"),
+            &0u32,
+            &owner,
+            &-1i128,
+        );
+        assert_eq!(result, Err(Ok(ContractError::InvalidPrice)));
+    }
+
+    #[test]
+    fn test_register_ip_valid_price() {
+        let (env, client, _admin) = setup();
+        let owner = Address::generate(&env);
+        let id = register(&client, &owner, b"QmHash", b"root", 1);
+        let listing = client.get_listing(&id).expect("listing should exist");
+        assert_eq!(listing.price_usdc, 1);
     }
 }


### PR DESCRIPTION
closes #260 


Fixes #260 — `register_ip` did not properly reject zero or negative prices with the dedicated `InvalidPrice` error.

## Root Cause

The validation guard checked `price_usdc < 0` as part of the `InvalidInput` condition, which short-circuited before the `InvalidPrice` check could fire. This meant:
- Negative prices → returned `InvalidInput` (wrong error)
- Zero price → the `InvalidPrice` check fired, but only after the contract was already initialized (a pre-existing test used an uninitialized contract, causing a panic instead)

## Changes

- **`contracts/ip_registry/src/lib.rs`**
  - Removed `price_usdc < 0` from the `InvalidInput` guard
  - `price_usdc <= 0` now exclusively returns `ContractError::InvalidPrice` for both zero and negative values
  - Fixed `test_register_rejects_negative_price` to assert `InvalidPrice` (was incorrectly asserting `InvalidInput`)
  - Fixed `test_register_rejects_zero_price` to use the `setup()` helper (was using an uninitialized contract)
  - Added `test_register_ip_zero_price`, `test_register_ip_negative_price`, `test_register_ip_valid_price`

## Testing

All existing tests continue to pass. Three new tests cover the acceptance criteria from the issue.


- Remove price_usdc < 0 from InvalidInput guard so negative prices are no longer swallowed before the InvalidPrice check fires
- price_usdc <= 0 now correctly returns InvalidPrice for both 0 and negative values
- Fix test_register_rejects_negative_price to expect InvalidPrice
- Fix test_register_rejects_zero_price to use initialized setup()
- Add test_register_ip_zero_price, test_register_ip_negative_price, and test_register_ip_valid_price per issue requirements

