### PR TITLE
fix: update CI badge URL to MerkleMint/Atomic-IP-Marketplace (#474)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Atomic IP Marketplace
 
-[![CI](https://github.com/unixfundz/Atomic-IP-Marketplace/actions/workflows/ci.yml/badge.svg)](https://github.com/unixfundz/Atomic-IP-Marketplace/actions/workflows/ci.yml)
+[![CI](https://github.com/MerkleMint/Atomic-IP-Marketplace/actions/workflows/ci.yml/badge.svg)](https://github.com/MerkleMint/Atomic-IP-Marketplace/actions/workflows/ci.yml)
 
 Soroban smart contracts for atomic IP swaps using USDC, IP registry, and ZK verification.
 


### PR DESCRIPTION
closes #474 