### PR TITLE
fix: extend TTL on get_listing reads and add near-expiry persistence …

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -867,6 +867,34 @@ mod test {
     }
 
     #[test]
+    fn test_get_listing_extends_ttl_near_expiry() {
+        // Advance to just below the TTL threshold so the entry is close to
+        // expiring, then call get_listing — which must extend the TTL.
+        // Afterwards, advance by another THRESHOLD worth of ledgers and
+        // confirm the listing is still accessible (it would be gone without
+        // the extension).
+        let (env, client, _admin) = setup();
+        let owner = Address::generate(&env);
+        let id = register(&client, &owner, b"QmNearExpiry", b"root", 1);
+
+        // Advance to just inside the threshold window (TTL is about to drop
+        // below THRESHOLD, triggering extend_ttl on the next read).
+        let near_expiry = EXTEND_TO - THRESHOLD + 1;
+        env.ledger().with_mut(|li| li.sequence_number += near_expiry);
+
+        // This read should extend the TTL to EXTEND_TO from the current ledger.
+        assert!(client.get_listing(&id).is_some(), "listing should exist near expiry");
+
+        // Advance another THRESHOLD ledgers — without the extension the entry
+        // would have expired, but with it the listing must still be present.
+        env.ledger().with_mut(|li| li.sequence_number += THRESHOLD);
+        assert!(
+            client.get_listing(&id).is_some(),
+            "listing should persist after TTL was extended by get_listing"
+        );
+    }
+
+    #[test]
     fn test_counter_persists_across_ttl_boundary() {
         let (env, client, _admin) = setup();
         let owner = Address::generate(&env);


### PR DESCRIPTION
## Summary

Active listings that are frequently read but never written could silently
expire from persistent storage because `get_listing` wasn't refreshing
their TTL. This PR confirms the fix is in place and adds a regression test
to cover the scenario.

## Changes

- `contracts/ip_registry/src/lib.rs` — `get_listing` already calls
  `extend_persistent` on the listing key when the entry exists, keeping
  the TTL alive on every read.
- Added `test_get_listing_extends_ttl_near_expiry`: registers a listing,
  advances the ledger to just inside the TTL threshold window, calls
  `get_listing` (triggering the extension), then advances another
  `THRESHOLD` ledgers — a range that would have expired the entry without
  the extension — and asserts the listing is still present.

## Why

Without TTL extension on reads, a listing that is only ever queried (never
updated) will eventually fall off persistent storage even though it appears
active. The test makes this guarantee explicit and prevents regressions.

## Testing

cargo test test_get_listing_extends_ttl_near_expiry -p ip_registry

this pr Closes #117 