### PR TITLE
fix: Explicit Fee Validation in initiate_swap

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -213,6 +213,12 @@ impl AtomicSwap {
         fee
     }
 
+    fn validate_fee_amount(env: &Env, usdc_amount: i128, fee_bps: u32) {
+        // Intentionally compute the fee up front so initiate_swap preserves the
+        // truncation check even if the returned fee is not otherwise needed yet.
+        let _validated_fee = Self::calculate_fee_amount(env, usdc_amount, fee_bps);
+    }
+
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -379,8 +385,7 @@ impl AtomicSwap {
             .instance()
             .get(&DataKey::Config)
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotInitialized));
-        // Validate fee calculation; panics if fee would truncate to zero
-        let _fee = Self::calculate_fee_amount(&env, usdc_amount, config.fee_bps);
+        Self::validate_fee_amount(&env, usdc_amount, config.fee_bps);
 
         let now = env.ledger().timestamp();
         let expires_at = now.saturating_add(config.swap_expiry_secs);


### PR DESCRIPTION
Fixes implicit fee validation logic.

- Assigns result of calculate_fee_amount
- Adds explicit validation intent
- Prevents silent break on refactor

closes #514

Explanation:
Removes hidden side-effect dependency and makes validation explicit and maintainable.

Validation:
- cargo fmt
- cargo test currently fails due an unrelated pre-existing compile error in contracts/ip_registry/src/lib.rs (undefined new_price_usdc/new_royalty_bps in update_listing)