### PR TITLE
fix: validate fee_bps <= 10_000 in initialize and add regression test

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -2749,6 +2749,7 @@ mod test {
             &10_001u32,
             &fee_recipient,
             &3600u64,
+            &86_400u64,
             &zk_verifier,
             &ip_registry,
         );


### PR DESCRIPTION
## Problem

Closes #522 

`initialize()` accepted any `fee_bps` value, including values > 10,000 (> 100%).
When such a contract was used, `release_to_seller` would compute a fee larger than
the swap amount, causing an arithmetic underflow panic.

## Changes

- **`ContractError::FeeBpsTooHigh` (variant #21)** — new error variant for this
  specific invalid-input case.
- **`initialize()` guard** — rejects `fee_bps > 10_000` with `FeeBpsTooHigh`
  *before* writing any state to storage, so no partial initialization can occur.
- **`test_initialize_rejects_fee_bps_too_high`** — regression test that calls
  `initialize` with `fee_bps = 10_001` and asserts the contract panics with
  `Error(Contract, #21)`.
- Fixed a pre-existing bug in the test: missing `swap_expiry_secs` argument in
  the `initialize` call.

## Why 10,000?

A basis point is 1/100th of 1%, so 10,000 bps = 100%. Any value above that
would make the computed fee exceed the principal, which is mathematically invalid
for a fee calculation.

## Testing


cargo test --locked -p atomic_swap -- test_initialize_rejects_fee_bps_too_high

