### PR TITLE
fix(deploy): initialize ip_registry on deploy; rename SwapCompleted

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,15 @@ VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 VITE_CONTRACT_ATOMIC_SWAP=
 VITE_CONTRACT_IP_REGISTRY=
 VITE_CONTRACT_ZK_VERIFIER=
+
+# Deployment / contract initialization
+ATOMIC_SWAP_ADMIN=
+ATOMIC_SWAP_FEE_RECIPIENT=
+ATOMIC_SWAP_FEE_BPS=250
+ATOMIC_SWAP_CANCEL_DELAY_SECS=3600
+
+# ip_registry TTL settings (in ledgers; ~5 days at 6s/ledger ≈ 72000 ledgers)
+# IP_REGISTRY_TTL_THRESHOLD: ledgers remaining before TTL is extended
+# IP_REGISTRY_TTL_EXTEND_TO: ledgers to extend TTL to when threshold is hit
+IP_REGISTRY_TTL_THRESHOLD=100000
+IP_REGISTRY_TTL_EXTEND_TO=200000

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -102,6 +102,12 @@ pub enum DataKey {
     AllowedToken(Address),
 }
 
+/// Event lifecycle:
+///   1. SwapInitiated      — buyer locks funds and initiates the swap
+///   2. SwapKeySubmitted   — seller submits the decryption key; dispute window begins
+///   3. FundsReleased      — dispute window elapsed, funds transferred to seller (swap settled)
+///      SwapCancelled      — buyer cancels before seller confirms (funds returned)
+
 #[contractevent]
 pub struct SwapInitiated {
     #[topic]
@@ -129,9 +135,11 @@ pub struct SwapCancelled {
     pub usdc_amount: i128,
 }
 
-/// Emitted when a swap is completed and funds are released to the seller.
+/// Emitted by confirm_swap when the seller submits the decryption key.
+/// The dispute window starts here; funds are NOT yet released.
+/// Listen for FundsReleased to confirm settlement.
 #[contractevent]
-pub struct SwapCompleted {
+pub struct SwapKeySubmitted {
     #[topic]
     pub swap_id: u64,
     pub seller: Address,
@@ -561,7 +569,7 @@ impl AtomicSwap {
         }
         .publish(&env);
 
-        SwapCompleted {
+        SwapKeySubmitted {
             swap_id,
             seller: swap.seller,
         }
@@ -2332,16 +2340,16 @@ mod test {
 
         client.confirm_swap(&swap_id, &key_bytes, &proof_path);
 
-        // SwapCompleted: topics = ["swap_completed", swap_id]; data = map { seller: address }
+        // SwapKeySubmitted: topics = ["swap_key_submitted", swap_id]; data = map { seller: address }
         let swap_id_xdr = soroban_sdk::xdr::ScVal::try_from_val(&env, &<u64 as IntoVal<Env, soroban_sdk::Val>>::into_val(&swap_id, &env)).unwrap();
-        let name_xdr = soroban_sdk::xdr::ScVal::Symbol("swap_completed".try_into().unwrap());
+        let name_xdr = soroban_sdk::xdr::ScVal::Symbol("swap_key_submitted".try_into().unwrap());
         let found = env.events().all().filter_by_contract(&contract_id).events().iter().any(|e| {
             let body = match &e.body { soroban_sdk::xdr::ContractEventBody::V0(b) => b };
             body.topics.len() == 2
                 && body.topics[0] == name_xdr
                 && body.topics[1] == swap_id_xdr
         });
-        assert!(found, "SwapCompleted event not emitted on confirm_swap");
+        assert!(found, "SwapKeySubmitted event not emitted on confirm_swap");
     }
 
     #[test]

--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -19,6 +19,8 @@ fi
 : "${ATOMIC_SWAP_FEE_BPS:=0}"
 : "${ATOMIC_SWAP_FEE_RECIPIENT:?ATOMIC_SWAP_FEE_RECIPIENT must be set in .env}"
 : "${ATOMIC_SWAP_CANCEL_DELAY_SECS:=3600}"
+: "${IP_REGISTRY_TTL_THRESHOLD:=100000}"
+: "${IP_REGISTRY_TTL_EXTEND_TO:=200000}"
 
 echo "Deploying to testnet..."
 
@@ -38,6 +40,20 @@ deploy_contract() {
 IP_REGISTRY=$(deploy_contract target/wasm32-unknown-unknown/release/ip_registry.wasm)
 ATOMIC_SWAP=$(deploy_contract target/wasm32-unknown-unknown/release/atomic_swap.wasm)
 ZK_VERIFIER=$(deploy_contract target/wasm32-unknown-unknown/release/zk_verifier.wasm)
+
+echo "Initializing ip_registry contract..."
+if ! stellar contract invoke \
+  --id "$IP_REGISTRY" \
+  --network "$STELLAR_NETWORK" \
+  --source deployer \
+  -- \
+  initialize \
+  --admin "$ATOMIC_SWAP_ADMIN" \
+  --ttl_threshold "$IP_REGISTRY_TTL_THRESHOLD" \
+  --ttl_extend_to "$IP_REGISTRY_TTL_EXTEND_TO"; then
+  echo "Failed to initialize ip_registry contract: $IP_REGISTRY" >&2
+  exit 1
+fi
 
 echo "Initializing atomic swap contract..."
 if ! stellar contract invoke \


### PR DESCRIPTION
closes #549 
closes #584  

> fix(deploy): initialize ip_registry on deploy; rename SwapCompleted to SwapKeySubmitted

## Bug: ip_registry not initialized on deployment

deploy_testnet.sh deployed all three contracts but only called
initialize on atomic_swap. ip_registry requires
initialize(admin, ttl_threshold, ttl_extend_to) before any function
can be called — any call to register_ip on a freshly deployed contract
would panic with NotInitialized.

Changes:
- Add IP_REGISTRY_TTL_THRESHOLD and IP_REGISTRY_TTL_EXTEND_TO env vars
  with defaults (100000 / 200000 ledgers, ~7–14 days at 6s/ledger)
- Add initialize invocation for ip_registry immediately after deploy,
  reading admin from ATOMIC_SWAP_ADMIN
- Document both TTL vars in .env.example with unit explanation

## Enhancement: clarify SwapCompleted event semantics

SwapCompleted was emitted by confirm_swap when the seller submits the
decryption key. The name implied the swap was fully settled, but funds
are not transferred until release_to_seller is called after the dispute
window. This forced indexers to track two events (SwapCompleted +
FundsReleased) with confusing overlap.

Changes:
- Rename SwapCompleted -> SwapKeySubmitted to accurately reflect that
  the seller has submitted the key and the dispute window has started,
  but funds have not yet moved
- Add a lifecycle comment block above the event structs documenting the
  full event sequence:
    SwapInitiated -> SwapKeySubmitted -> FundsReleased (settled)
                                      -> SwapCancelled (refunded)
- Update the emit call in confirm_swap and the corresponding test
  assertion to use the new name and topic string "swap_key_submitted"
