### PR TITLE
fix(ci): set VITE_* env vars before frontend build and add post-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Set up environment variables for build
+        run: cp .env.example .env
+
       - name: Typecheck
         run: npm run typecheck
 
       - name: Build
         run: npm run build
+
+      - name: Verify no undefined contract addresses in bundle
+        run: |
+          set -e
+          BUNDLE_DIR=dist/assets
+          if ! ls "$BUNDLE_DIR"/*.js 1>/dev/null 2>&1; then
+            echo "ERROR: No JS bundle files found in $BUNDLE_DIR"
+            exit 1
+          fi
+          if grep -r '"undefined"' "$BUNDLE_DIR"/*.js | grep -iE '(contract|registry|swap|verifier|stellar)'; then
+            echo "ERROR: Bundle contains undefined contract address(es). Check VITE_CONTRACT_* env vars."
+            exit 1
+          fi
+          echo "OK: No undefined contract addresses detected in bundle."


### PR DESCRIPTION
closes #580 

## fix(ci): set VITE_* env vars before frontend build

**Problem**

The CI frontend job ran `npm run build` with no `VITE_CONTRACT_*` or `VITE_STELLAR_*` env vars set. Vite replaces `import.meta.env.VITE_*` at build time, so missing vars silently bake `undefined` into the bundle — build passes, runtime breaks.

**Changes**

- Added a step that copies `frontend/.env.example` to `frontend/.env` before the build runs
- Added a post-build check that greps the output bundle (`dist/assets/*.js`) for `"undefined"` near contract-related identifiers and fails the job if found

**Testing**

CI will now catch any future case where a required `VITE_CONTRACT_*` var is missing before the broken bundle can be deployed.