### PR TITLE
fix(deploy): add missing --zk_verifier arg to atomic_swap initialize

### DIFF
--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -65,7 +65,8 @@ if ! stellar contract invoke \
   --admin "$ATOMIC_SWAP_ADMIN" \
   --fee_bps "$ATOMIC_SWAP_FEE_BPS" \
   --fee_recipient "$ATOMIC_SWAP_FEE_RECIPIENT" \
-  --cancel_delay_secs "$ATOMIC_SWAP_CANCEL_DELAY_SECS"; then
+  --cancel_delay_secs "$ATOMIC_SWAP_CANCEL_DELAY_SECS" \
+  --zk_verifier "$ZK_VERIFIER"; then
   echo "Failed to initialize atomic swap contract: $ATOMIC_SWAP" >&2
   exit 1
 fi


### PR DESCRIPTION


The atomic_swap initialize invocation in deploy_testnet.sh was missing the --zk_verifier argument. The Config struct requires a zk_verifier: Address field, so the call would fail at runtime with a missing argument error.

Fix: pass --zk_verifier "$ZK_VERIFIER" (the address returned by the zk_verifier deploy step, which already exists in scope) to the atomic_swap initialize invocation.

Closes #475