### PR TITLE
fix(frontend): correct USDC decimal divisor in ListingCard 

### DIFF
--- a/frontend/src/components/ListingCard.tsx
+++ b/frontend/src/components/ListingCard.tsx
@@ -3,6 +3,7 @@ import { ConfirmSwapForm } from "./ConfirmSwapForm";
 import { SetMerkleRootForm } from "./SetMerkleRootForm";
 import "./ListingCard.css";
 import { CopyButton } from "./CopyButton";
+import { USDC_DECIMALS } from "../lib/contractClient";
 
 const IPFS_GATEWAY =
   import.meta.env.VITE_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs";
@@ -97,7 +98,7 @@ export function ListingCard({ listing, wallet, onUpdated }: IListingCard) {
         </div>
         {listing.price_usdc > 0 && (
           <span className="lc__price">
-            {listing.price_usdc / 1_000_000} USDC
+            {listing.price_usdc / Math.pow(10, USDC_DECIMALS)} USDC
           </span>
         )}
       </div>

--- a/frontend/src/lib/contractClient.ts
+++ b/frontend/src/lib/contractClient.ts
@@ -624,7 +624,8 @@ export async function getSwapsBySeller(sellerAddress: string) {
 // ─── USDC Balance ─────────────────────────────────────────────────────────────
 
 const USDC_CONTRACT_ID = CONTRACT_USDC;
-const USDC_DECIMALS = 7;
+// Stellar USDC uses 7 decimal places (10_000_000 stroops = 1 USDC)
+export const USDC_DECIMALS = 7;
 
 /**
  * Fetch the USDC balance for a given address by calling `balance(address)`


### PR DESCRIPTION
ListingCard was dividing price_usdc by 1_000_000 (6 decimals), causing all displayed prices to appear 10× too high. Stellar USDC uses 7 decimal places (10_000_000 stroops = 1 USDC).

Changes:
- Export USDC_DECIMALS = 7 from contractClient.ts with an explanatory comment (matches the convention already used in InitiateSwapModal, SwapCard, and ConfirmSwapForm)
- Import USDC_DECIMALS in ListingCard.tsx and replace the hardcoded 1_000_000 divisor with Math.pow(10, USDC_DECIMALS)

Closes #479