### PR TITLE
fix: guard update_listing against pending swaps

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -513,6 +513,8 @@ impl IpRegistry {
         listing_id: u64,
         new_ipfs_hash: Bytes,
         new_merkle_root: Bytes,
+        new_price_usdc: i128,
+        new_royalty_bps: u32,
         atomic_swap: Address,
     ) -> Result<(), ContractError> {
         assert_not_paused(&env);
@@ -1311,6 +1313,8 @@ mod test {
             &id,
             &Bytes::from_slice(&env, b"QmHashNew"),
             &Bytes::from_slice(&env, b"rootNew"),
+            &2000i128,
+            &0u32,
             &atomic_swap,
         );
     }
@@ -1321,12 +1325,14 @@ mod test {
         let owner = Address::generate(&env);
         let atomic_swap = Address::generate(&env);
         let id = register(&client, &owner, b"QmHash", b"root", 1000);
-        
+
         let result = client.try_update_listing(
             &owner,
             &id,
             &Bytes::new(&env),
             &Bytes::from_slice(&env, b"newRoot"),
+            &2000i128,
+            &0u32,
             &atomic_swap,
         );
         assert_eq!(result, Err(Ok(ContractError::InvalidInput)));
@@ -1338,12 +1344,14 @@ mod test {
         let owner = Address::generate(&env);
         let atomic_swap = Address::generate(&env);
         let id = register(&client, &owner, b"QmHash", b"root", 1000);
-        
+
         let result = client.try_update_listing(
             &owner,
             &id,
             &Bytes::from_slice(&env, b"newHash"),
             &Bytes::new(&env),
+            &2000i128,
+            &0u32,
             &atomic_swap,
         );
         assert_eq!(result, Err(Ok(ContractError::InvalidInput)));
@@ -1351,19 +1359,40 @@ mod test {
 
     #[test]
     fn test_update_listing_rejects_pending_swap() {
+        use atomic_swap::{AtomicSwap, DataKey as SwapDataKey, Swap, SwapStatus};
+
         let (env, client, _admin) = setup();
         let owner = Address::generate(&env);
-        let atomic_swap = Address::generate(&env);
         let id = register(&client, &owner, b"QmHash", b"root", 1000);
-        
-        env.mock_all_auths();
-        
+
+        // Register a real AtomicSwap contract and seed a Pending swap for this listing.
+        let swap_contract_id = env.register(AtomicSwap, ());
+        let swap_id: u64 = 1;
+        env.as_contract(&swap_contract_id, || {
+            let swap = Swap {
+                listing_id: id,
+                buyer: Address::generate(&env),
+                seller: owner.clone(),
+                usdc_amount: 1000,
+                usdc_token: Address::generate(&env),
+                created_at: 0,
+                expires_at: 9999,
+                status: SwapStatus::Pending,
+                decryption_key: None,
+                confirmed_at_ledger: None,
+            };
+            env.storage().persistent().set(&SwapDataKey::Swap(swap_id), &swap);
+            env.storage().persistent().set(&SwapDataKey::ActiveListingSwap(id), &swap_id);
+        });
+
         let result = client.try_update_listing(
             &owner,
             &id,
             &Bytes::from_slice(&env, b"newHash"),
             &Bytes::from_slice(&env, b"newRoot"),
-            &atomic_swap,
+            &2000i128,
+            &0u32,
+            &swap_contract_id,
         );
         assert_eq!(result, Err(Ok(ContractError::PendingSwapExists)));
     }


### PR DESCRIPTION
closes #513 

fix: guard update_listing against pending swaps

## Problem

update_listing in ip_registry had two related bugs:

1. Missing parameters (compile error)
The function body referenced new_price_usdc and new_royalty_bps — assigning them to the listing 
and validating new_price_usdc > 0 — but neither was declared in the function signature. This made
the contract uncompilable.

2. Mid-swap mutation vulnerability
update_listing allowed a seller to change ipfs_hash and merkle_root while a buyer's swap was in 
Pending status. The buyer constructs their ZK proof against the Merkle root at the time they 
initiate the swap. If the seller updates the root before confirm_swap is called, the proof 
verification fails and the buyer's USDC is locked until the swap expires — a griefing vector 
against buyers.

3. Broken test
test_update_listing_rejects_pending_swap passed a bare Address::generate() as the atomic_swap 
contract address. This would panic at the cross-contract call (no contract registered at that 
address) rather than returning PendingSwapExists, so the test never actually validated the guard.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


## Changes

### contracts/ip_registry/src/lib.rs

update_listing signature — added the two missing parameters:
rust
pub fn update_listing(
    env: Env,
    owner: Address,
    listing_id: u64,
    new_ipfs_hash: Bytes,
    new_merkle_root: Bytes,
    new_price_usdc: i128,   // ← added
    new_royalty_bps: u32,   // ← added
    atomic_swap: Address,
) -> Result<(), ContractError>


The pending-swap guard was already present in the body — it just couldn't compile without the 
missing params:
rust
if AtomicSwapClient::new(&env, &atomic_swap).has_pending_swap(&listing_id) {
    return Err(ContractError::PendingSwapExists);
}


test_update_listing_rejects_pending_swap — replaced the fake address with a real registered 
AtomicSwap contract, then used env.as_contract(...) to directly seed DataKey::Swap(1) with 
SwapStatus::Pending and DataKey::ActiveListingSwap(listing_id) pointing to it. This makes 
has_pending_swap return true through the actual contract logic, so the test genuinely validates 
the guard:
rust
let swap_contract_id = env.register(AtomicSwap, ());
env.as_contract(&swap_contract_id, || {
    env.storage().persistent().set(&SwapDataKey::Swap(1u64), &swap);
    env.storage().persistent().set(&SwapDataKey::ActiveListingSwap(id), &1u64);
});


All other update_listing call sites (test_update_listing_blocked_when_paused, 
test_update_listing_rejects_empty_ipfs_hash, test_update_listing_rejects_empty_merkle_root) 
updated to pass the two new params. Those tests still pass because their errors (ContractPaused, 
InvalidInput) fire before the pending-swap check is reached.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


## Testing

| Test | Validates |
|---|---|
| test_update_listing_blocked_when_paused | Paused contract rejects update |
| test_update_listing_rejects_empty_ipfs_hash | Empty hash rejected |
| test_update_listing_rejects_empty_merkle_root | Empty root rejected |
| test_update_listing_rejects_pending_swap | Guard returns PendingSwapExists when a real pending 
swap exists |