### PR TITLE
feat(frontend): wire RegisterListingForm into MyListingsDashboard (#506)

### DIFF
--- a/frontend/src/components/MyListingsDashboard.tsx
+++ b/frontend/src/components/MyListingsDashboard.tsx
@@ -1,6 +1,9 @@
 
+import { useState } from "react";
 import { useMyListings } from "../hooks/useMyListings";
 import { ListingCard } from "./ListingCard";
+import { RegisterListingForm } from "./RegisterListingForm";
+import { useWallet } from "../context/WalletContext";
 import type { Listing, Wallet } from "../lib/types";
 import "./MyListingsDashboard.css";
 
@@ -67,7 +70,7 @@ export function MyListingsDashboard() {
         <div className="mld__register-section">
           <RegisterListingForm 
             wallet={wallet} 
-            onSuccess={(id) => {
+            onSuccess={() => {
               setShowRegisterForm(false);
               refresh();
             }}


### PR DESCRIPTION
RegisterListingForm.tsx and contractClient.registerIp() already existed but MyListingsDashboard.tsx was missing the imports needed to use them, so the form was unreachable and the component would not compile.

Changes to MyListingsDashboard.tsx only:
- Import useState (was used but not imported)
- Import useWallet from WalletContext (was called but not imported)
- Import RegisterListingForm (was rendered but not imported)
- Fix onSuccess callback signature: (id) => {} → () => {} to match RegisterListingForm's Props interface

No new logic added — the form, contract call, validation, and dashboard toggle were all already implemented.

Closes #506