### PR TITLE
fix(ip_registry): extend TTL on OwnerIndex in deregister_listing

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -596,7 +596,9 @@ impl IpRegistry {
         if ids.is_empty() {
             env.storage().persistent().remove(&idx_key);
         } else {
+            let cfg = get_config(&env);
             env.storage().persistent().set(&idx_key, &ids);
+            extend_persistent(&env, &idx_key, &cfg);
         }
 
         IpDeregistered { listing_id, owner }.publish(&env);
@@ -1515,5 +1517,32 @@ mod test {
         let id = register(&client, &owner, b"QmHash", b"root", 1);
         let listing = client.get_listing(&id).expect("listing should exist");
         assert_eq!(listing.price_usdc, 1);
+    }
+
+    #[test]
+    fn test_deregister_listing_extends_ttl_near_expiry() {
+        // Advance to just before expiry, then call deregister.
+        // This must extend the TTL on the owner's index so remaining IDs persist.
+        let (env, client, _admin) = setup();
+        let owner = Address::generate(&env);
+        let id1 = register(&client, &owner, b"QmNearExpiry1", b"root", 1);
+        let id2 = register(&client, &owner, b"QmNearExpiry2", b"root", 1);
+
+        // Verify index is properly populated
+        assert_eq!(client.list_by_owner(&owner).len(), 2);
+
+        // Advance to just inside the threshold window (expiry is EXTEND_TO ledgers away)
+        let near_expiry = EXTEND_TO - THRESHOLD + 1;
+        env.ledger().with_mut(|li| li.sequence_number += near_expiry);
+
+        // This operation should trigger extend_ttl on the idx_key DataKey::OwnerIndex
+        client.deregister_listing(&owner, &id1, &None);
+
+        // Advance another THRESHOLD ledgers. Without extension, OwnerIndex would be gone.
+        env.ledger().with_mut(|li| li.sequence_number += THRESHOLD);
+        
+        let ids = client.list_by_owner(&owner);
+        assert_eq!(ids.len(), 1, "Owner index failed to persist after deregistration extension window");
+        assert_eq!(ids.get(0).unwrap(), id2);
     }
 }


### PR DESCRIPTION
### PR Summary: Fix IP Registry `OwnerIndex` TTL Extension (#561)

**Issue**: `deregister_listing` was updating the `OwnerIndex` (the mapping from owners to their listing IDs) but failed to call `extend_persistent` on the index key. This could lead to the owner's entire listing index expiring and being removed from storage if the last update occurred near the end of the 30-day window.

**Changes**:
- Modified [contracts/ip_registry/src/lib.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/Atomic-IP-Marketplace/contracts/ip_registry/src/lib.rs:0:0-0:0): In `deregister_listing`, after updating the list of IDs for an owner, `env.storage().persistent().extend_ttl(...)` is now called to ensure the index persists.
- Added a new regression test `test_deregister_listing_extends_ttl_near_expiry` that ensures the index survives into the next window when updated at the TTL boundary.

**Impact**: Ensures high data reliability for sellers' listing portfolios.

Closes #561 