### PR TITLE
fix(atomic_swap): use gross usdc_amount as royalty base in release_to_seller and resolve_dispute

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -619,8 +619,9 @@ impl AtomicSwap {
             token_client.transfer(&contract_addr, &config.fee_recipient, &fee);
         }
 
-        // Deduct royalty
-        let royalty: i128 = (seller_amount * listing.royalty_bps as i128) / 10_000;
+        // Royalty is calculated on the gross sale price (swap.usdc_amount), not the
+        // post-fee amount, so royalty semantics are independent of the protocol fee.
+        let royalty: i128 = (swap.usdc_amount * listing.royalty_bps as i128) / 10_000;
         if royalty > 0 {
             token_client.transfer(&contract_addr, &listing.royalty_recipient, &royalty);
             seller_amount -= royalty;
@@ -728,8 +729,9 @@ impl AtomicSwap {
                 token_client.transfer(&contract_addr, &config.fee_recipient, &fee);
             }
 
-            // Deduct royalty
-            let royalty: i128 = (seller_amount * listing.royalty_bps as i128) / 10_000;
+            // Royalty is calculated on the gross sale price (swap.usdc_amount), not the
+            // post-fee amount, so royalty semantics are independent of the protocol fee.
+            let royalty: i128 = (swap.usdc_amount * listing.royalty_bps as i128) / 10_000;
             if royalty > 0 {
                 token_client.transfer(&contract_addr, &listing.royalty_recipient, &royalty);
                 seller_amount -= royalty;
@@ -1952,12 +1954,11 @@ mod test {
 
         let usdc = token::Client::new(&env, &usdc_id);
         // fee = 1000 * 200 / 10_000 = 20
-        // seller_pre_royalty = 1000 - 20 = 980
-        // royalty = 980 * 500 / 10_000 = 49
-        // seller_final = 980 - 49 = 931
+        // royalty = 1000 * 500 / 10_000 = 50  (gross base, independent of fee)
+        // seller_final = 1000 - 20 - 50 = 930
         assert_eq!(usdc.balance(&fee_recipient), 20);
-        assert_eq!(usdc.balance(&royalty_recipient), 49);
-        assert_eq!(usdc.balance(&seller), 931);
+        assert_eq!(usdc.balance(&royalty_recipient), 50);
+        assert_eq!(usdc.balance(&seller), 930);
     }
 
     #[test]
@@ -2151,6 +2152,56 @@ mod test {
         assert_eq!(usdc_client.balance(&seller), 900);
         // Royalty recipient should receive 100
         assert_eq!(usdc_client.balance(&royalty_recipient), 100);
+    }
+
+    /// Issue #569: royalty must be computed on gross swap.usdc_amount, not post-fee amount.
+    /// With fee_bps=200 (2%) and royalty_bps=500 (5%) on 1000 USDC:
+    ///   fee    = 1000 * 200 / 10_000 = 20
+    ///   royalty = 1000 * 500 / 10_000 = 50  (gross base)
+    ///   seller  = 1000 - 20 - 50 = 930
+    #[test]
+    fn test_royalty_base_is_gross_amount_not_post_fee() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let royalty_recipient = Address::generate(&env);
+        let fee_recipient = Address::generate(&env);
+
+        let usdc_id = setup_usdc(&env, &buyer, 1000);
+        let registry_id = env.register(IpRegistry, ());
+        let registry = IpRegistryClient::new(&env, &registry_id);
+        let reg_admin = Address::generate(&env);
+        registry.initialize(&reg_admin, &100_000u32, &6_312_000u32);
+        let listing_id = registry.register_ip(
+            &seller,
+            &Bytes::from_slice(&env, b"QmHash"),
+            &Bytes::from_slice(&env, b"root"),
+            &500u32, // 5% royalty
+            &royalty_recipient,
+            &1i128,
+        );
+
+        let key_bytes = Bytes::from_slice(&env, b"key");
+        let (zk_id, proof_path) = setup_zk_verifier(&env, &seller, listing_id, &key_bytes);
+
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+        // fee_bps = 200 (2%)
+        client.initialize(&Address::generate(&env), &200u32, &fee_recipient, &60u64, &zk_id, &registry_id);
+        client.add_allowed_token(&usdc_id);
+
+        let swap_id = client.initiate_swap(&listing_id, &buyer, &seller, &usdc_id, &1000);
+        client.confirm_swap(&swap_id, &key_bytes, &proof_path);
+        client.set_dispute_window(&10u32);
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        client.release_to_seller(&swap_id);
+
+        let usdc = token::Client::new(&env, &usdc_id);
+        assert_eq!(usdc.balance(&fee_recipient), 20);
+        assert_eq!(usdc.balance(&royalty_recipient), 50);
+        assert_eq!(usdc.balance(&seller), 930);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Royalty was computed on `seller_amount` (post-fee), making royalty semantics dependent on whether a protocol fee is charged. This makes royalty amounts unpredictable and inconsistent between zero-fee and non-zero-fee configurations.

## Changes

- In `release_to_seller`: compute royalty as `swap.usdc_amount * royalty_bps / 10_000` (gross)
- In `resolve_dispute` (favor-seller path): same fix applied consistently
- Updated `test_release_to_seller_pays_royalties` to reflect correct gross-base amounts
- Added `test_royalty_base_is_gross_amount_not_post_fee` verifying royalty with non-zero fee and non-zero royalty_bps

Closes #569