### PR TITLE
fix(atomic_swap): remove duplicate ActiveListingSwap removal in cancel_swap

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -794,9 +794,6 @@ impl AtomicSwap {
             .persistent()
             .remove(&DataKey::ActiveListingSwap(swap.listing_id));
         env.storage()
-            .persistent()
-            .remove(&DataKey::ActiveListingSwap(swap.listing_id));
-        env.storage()
             .instance()
             .extend_ttl(PERSISTENT_TTL_LEDGERS, PERSISTENT_TTL_LEDGERS);
 
@@ -2575,7 +2572,7 @@ mod test {
         assert!(client.is_listing_available(&listing_id));
     }
 
-    /// Issue #322: cancel_swap must remove ActiveListingSwap so a new buyer can
+    /// Issue #572: cancel_swap must remove ActiveListingSwap so a new buyer can
     /// immediately initiate a swap on the same listing without hitting SwapAlreadyPending.
     #[test]
     fn test_cancel_and_reinitiate_swap() {


### PR DESCRIPTION
## Summary

`cancel_swap` was calling `env.storage().persistent().remove(&DataKey::ActiveListingSwap(swap.listing_id))` twice in a row — a duplicate that was introduced when the fix was originally applied. The stale `ActiveListingSwap` entry is correctly removed by the single call; the duplicate is unnecessary.

## Changes

- Removed the duplicate `remove` call in `cancel_swap`
- Updated test comment to reference issue #572 (was referencing #322)

The existing `test_cancel_and_reinitiate_swap` test already covers the correct behavior: cancelling a swap and immediately initiating a new one on the same listing succeeds without hitting `SwapAlreadyPending`.

Closes #572