### PR TITLE
Clear frontend example contract IDs

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,11 +3,12 @@ VITE_STELLAR_NETWORK=testnet
 VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 
 # Contract Addresses (Required)
-# Use your deployed contract IDs here.
-VITE_CONTRACT_IP_REGISTRY=CBCGBBLBCCF6PZLSIFHCZZAEO33UPZVQAOZQBJBVZWWRFJZQTKLFFYBY
-VITE_CONTRACT_ATOMIC_SWAP=CAQC36PDQX5QKHLZSWX2HHFBBFWJ3PQZMU4DO7ARUDJJQ2EKGJQ4Y3
-VITE_CONTRACT_ZK_VERIFIER=CARGO3SRYJ6RDDTZ6IWDDNZCWWT6EATOHJPFB2WZYAANXHSZFVFHSX
-VITE_CONTRACT_USDC=... (replace with your USDC token contract address)
+# Fill these after deploying your own contracts. The deploy script prints the
+# generated IDs: ../scripts/deploy_testnet.sh
+VITE_CONTRACT_IP_REGISTRY=
+VITE_CONTRACT_ATOMIC_SWAP=
+VITE_CONTRACT_ZK_VERIFIER=
+VITE_CONTRACT_USDC=
 
 # IPFS Gateway (used for metadata preview)
 VITE_IPFS_GATEWAY=https://gateway.pinata.cloud/ipfs


### PR DESCRIPTION
Fixes #424.

## Summary
- remove hardcoded testnet contract IDs from `frontend/.env.example`
- leave empty placeholders for deployer-specific contract IDs
- point developers to `../scripts/deploy_testnet.sh` as the source of generated IDs

## Verification
- rg -n "VITE_CONTRACT_(IP_REGISTRY|ATOMIC_SWAP|ZK_VERIFIER)=C|replace with your|deploy_testnet" frontend/.env.example
- git diff --check