### PR TITLE
Move Vite contract env vars to frontend section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,6 @@ CONTRACT_ATOMIC_SWAP=
 CONTRACT_IP_REGISTRY=
 CONTRACT_ZK_VERIFIER=
 
-# Frontend contract addresses (Vite env vars — copy CONTRACT_* values above into VITE_CONTRACT_* after deployment)
-VITE_CONTRACT_ATOMIC_SWAP=
-VITE_CONTRACT_IP_REGISTRY=
-VITE_CONTRACT_ZK_VERIFIER=
-VITE_CONTRACT_USDC=
-
 # IPFS configuration
 IPFS_GATEWAY=https://gateway.pinata.cloud
 PINATA_API_KEY=
@@ -20,6 +14,11 @@ PINATA_API_KEY=
 # Frontend configuration
 VITE_STELLAR_NETWORK=testnet
 VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+# Copy CONTRACT_* values above into VITE_CONTRACT_* after deployment.
+VITE_CONTRACT_ATOMIC_SWAP=
+VITE_CONTRACT_IP_REGISTRY=
+VITE_CONTRACT_ZK_VERIFIER=
+VITE_CONTRACT_USDC=
 
 # Deployment / contract initialization
 ATOMIC_SWAP_ADMIN=


### PR DESCRIPTION
Fixes #384.

## Summary
- remove VITE contract variables from the contract-address block
- keep VITE contract variables under the frontend configuration section
- add a note to copy deployed `CONTRACT_*` values into `VITE_CONTRACT_*`

## Verification
- sed -n "1,35p" .env.example
- git diff --check