### PR TITLE
Allow zk verifier override during deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ ATOMIC_SWAP_FEE_RECIPIENT=
 ATOMIC_SWAP_FEE_BPS=250
 ATOMIC_SWAP_CANCEL_DELAY_SECS=3600
 ATOMIC_SWAP_EXPIRY_SECS=86400
+# Optional: reuse an existing zk_verifier contract instead of deploying a new one.
+ATOMIC_SWAP_ZK_VERIFIER=
 
 # ip_registry TTL settings (in ledgers; ~5 days at 6s/ledger ≈ 72000 ledgers)
 # IP_REGISTRY_TTL_THRESHOLD: ledgers remaining before TTL is extended

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ cp .env.example .env
 | `ATOMIC_SWAP_FEE_RECIPIENT` | Address that receives protocol fees |
 | `ATOMIC_SWAP_FEE_BPS` | Fee in basis points (e.g. `250` = 2.5%) |
 | `ATOMIC_SWAP_CANCEL_DELAY_SECS` | Seconds before a buyer can cancel (e.g. `3600`) |
+| `ATOMIC_SWAP_ZK_VERIFIER` | Optional existing zk_verifier contract ID; if empty, `deploy_testnet.sh` deploys one and uses it |
 
 ### Build contracts
 

--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -40,7 +40,12 @@ deploy_contract() {
 
 IP_REGISTRY=$(deploy_contract target/wasm32-unknown-unknown/release/ip_registry.wasm)
 ATOMIC_SWAP=$(deploy_contract target/wasm32-unknown-unknown/release/atomic_swap.wasm)
-ZK_VERIFIER=$(deploy_contract target/wasm32-unknown-unknown/release/zk_verifier.wasm)
+if [[ -n "${ATOMIC_SWAP_ZK_VERIFIER:-}" ]]; then
+  ZK_VERIFIER="$ATOMIC_SWAP_ZK_VERIFIER"
+  echo "Using existing zk_verifier contract: $ZK_VERIFIER"
+else
+  ZK_VERIFIER=$(deploy_contract target/wasm32-unknown-unknown/release/zk_verifier.wasm)
+fi
 
 echo "Initializing ip_registry contract..."
 if ! stellar contract invoke \


### PR DESCRIPTION
Fixes #382.

## Summary
- allow `ATOMIC_SWAP_ZK_VERIFIER` to reuse an existing zk_verifier during deployment
- default to deploying a new zk_verifier when no override is provided
- document the override in `.env.example` and README

## Verification
- bash -n scripts/deploy_testnet.sh
- rg -n "ATOMIC_SWAP_ZK_VERIFIER|--zk_verifier|Using existing" scripts/deploy_testnet.sh .env.example README.md
- git diff --check