### PR TITLE
Rename deploy script and add network flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ test:
 	@bash scripts/test.sh
 
 deploy-testnet:
-	@bash scripts/deploy_testnet.sh
+	@bash scripts/deploy.sh --network testnet
 
 deploy-mainnet:
 	@echo "WARNING: You are about to deploy to MAINNET."
 	@echo "This action is irreversible. Type 'yes' to continue:"
 	@read confirm && [ "$$confirm" = "yes" ] || (echo "Aborted." && exit 1)
-	@STELLAR_NETWORK=mainnet bash scripts/deploy_testnet.sh
+	@bash scripts/deploy.sh --network mainnet

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This runs `cargo test --locked --workspace` across all three contracts.
 3. Set `STELLAR_NETWORK=local` and `STELLAR_RPC_URL=http://localhost:8000/soroban/rpc` in `.env`.
 4. Deploy:
    ```bash
-   ./scripts/deploy_testnet.sh
+   ./scripts/deploy.sh --network local
    ```
 
 ### Frontend
@@ -112,9 +112,16 @@ Run tests:
 ./scripts/test.sh
 ```
 
-## Deploy (Testnet)
+## Deploy
 ```bash
-./scripts/deploy_testnet.sh
+./scripts/deploy.sh --network testnet
+```
+
+For mainnet, use a funded mainnet deployer account and review RPC, fee,
+TTL, admin, and verifier settings before confirming:
+
+```bash
+make deploy-mainnet
 ```
 
 ## Security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ Preferred reporting format:
 ## Scope
 This policy applies to:
 - Soroban contracts: `atomic_swap`, `ip_registry`, `zk_verifier`.
-- Deployment scripts (`deploy_testnet.sh`).
+- Deployment scripts (`deploy.sh`).
 - Related infrastructure under our control.
 
 ## Known Limitations

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -118,5 +118,5 @@ for contract in "${CONTRACTS[@]}"; do
     fi
 done
 echo ""
-echo "Deploy with: ./scripts/deploy_testnet.sh"
+echo "Deploy with: ./scripts/deploy.sh --network testnet"
 echo "================================================================"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,21 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
+NETWORK_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --network)
+      NETWORK_ARG="${2:?--network requires a value}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--network testnet|mainnet|local]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [[ -f .env ]]; then
   source .env
 elif [[ -f .env.example ]]; then
@@ -15,6 +30,9 @@ else
 fi
 
 : "${STELLAR_NETWORK:=testnet}"
+if [[ -n "$NETWORK_ARG" ]]; then
+  STELLAR_NETWORK="$NETWORK_ARG"
+fi
 : "${ATOMIC_SWAP_ADMIN:?ATOMIC_SWAP_ADMIN must be set in .env}"
 : "${ATOMIC_SWAP_FEE_BPS:=0}"
 : "${ATOMIC_SWAP_FEE_RECIPIENT:?ATOMIC_SWAP_FEE_RECIPIENT must be set in .env}"
@@ -23,7 +41,12 @@ fi
 : "${IP_REGISTRY_TTL_THRESHOLD:=100000}"
 : "${IP_REGISTRY_TTL_EXTEND_TO:=200000}"
 
-echo "Deploying to testnet..."
+if [[ "$STELLAR_NETWORK" == "mainnet" ]]; then
+  echo "WARNING: deploying to MAINNET."
+  echo "Confirm deployer is funded and mainnet fee, TTL, RPC, and admin settings are correct."
+fi
+
+echo "Deploying to $STELLAR_NETWORK..."
 
 deploy_contract() {
   local wasm_path="$1"


### PR DESCRIPTION
Fixes #387.

## Summary
- rename `scripts/deploy_testnet.sh` to `scripts/deploy.sh`
- add a `--network` flag that defaults to the existing `.env`/testnet behavior
- update Makefile, README, build output, and security docs to use the new script name
- print a prominent warning when deploying with `--network mainnet`

## Verification
- bash -n scripts/deploy.sh scripts/build.sh
- rg -n "deploy_testnet" README.md Makefile scripts SECURITY.md .env.example frontend/.env.example
- git diff --check