### PR TITLE
Use locked dependencies in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-test-
 
       - name: Run tests
-        run: cargo test --workspace
+        # Keep CI pinned to Cargo.lock so dependency drift cannot pass unnoticed.
+        run: cargo test --locked --workspace
 
   lint:
     name: Clippy & Rustfmt


### PR DESCRIPTION
Fixes #451.

## Summary
- run CI tests with `cargo test --locked --workspace`
- add a short comment explaining that CI should respect `Cargo.lock`

## Verification
- git diff --check
- inspected `.github/workflows/ci.yml` test step