### PR TITLE
feat(atomic_swap): implement escrow hold period configuration

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -8,6 +8,13 @@ use zk_verifier::{ProofNode, ZkVerifierClient};
 
 const PERSISTENT_TTL_LEDGERS: u32 = 6_312_000;
 const DEFAULT_DISPUTE_WINDOW_LEDGERS: u32 = 17_280;
+/// Default escrow hold period applied when a seller enables holds without
+/// specifying a custom value: 24 hours expressed in seconds.
+const DEFAULT_HOLD_PERIOD_SECS: u64 = 86_400;
+/// Upper bound on a configurable hold period (30 days). Capping the value
+/// prevents a seller (or admin) from locking buyer funds indefinitely and
+/// blocks hold-period manipulation that would grief the counterparty.
+const MAX_HOLD_PERIOD_SECS: u64 = 2_592_000;
 
 //Added enum
 
@@ -50,6 +57,12 @@ pub enum ContractError {
     /// Buyer's token allowance for this contract is below usdc_amount.
     /// Buyer must call `token.approve(contract, amount)` before initiating.
     InsufficientAllowance = 24,
+    /// release_to_seller called while the escrow hold period is still active and
+    /// the buyer has not confirmed receipt. Funds remain locked until the hold
+    /// period elapses or the buyer calls confirm_receipt.
+    HoldPeriodActive = 25,
+    /// A configured hold period exceeds MAX_HOLD_PERIOD_SECS.
+    HoldPeriodTooLong = 26,
 }
 
 #[contracttype]
@@ -63,6 +76,27 @@ pub enum SwapStatus {
     ResolvedSeller,
 }
 
+/// Protocol-wide escrow hold configuration.
+///
+/// Hold economics: after a swap is completed (seller submits the decryption key)
+/// the seller's payout can be held for an additional, seller-configurable window
+/// on top of the dispute window. During the hold the buyer may verify the
+/// delivered IP and, if satisfied, call `confirm_receipt` to release funds
+/// immediately. The hold gives honest buyers time to confirm and discourages a
+/// seller from sweeping funds the instant the dispute window lapses, while the
+/// MAX_HOLD_PERIOD_SECS cap and the immutability of `hold_until` (captured at
+/// confirm time) prevent a seller from weaponising the hold against the buyer.
+///
+/// `enabled` defaults to `false` so existing swaps are unaffected unless the
+/// admin turns the feature on globally or a seller opts in via
+/// `set_seller_hold_period`.
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub struct EscrowHoldConfig {
+    pub enabled: bool,
+    pub default_hold_period_secs: u64,
+}
+
 #[contracttype]
 #[derive(Clone, PartialEq, Debug)]
 pub struct Config {
@@ -73,6 +107,7 @@ pub struct Config {
     pub swap_expiry_secs: u64,
     pub zk_verifier: Address,
     pub ip_registry: Address,
+    pub escrow_hold: EscrowHoldConfig,
 }
 
 #[contracttype]
@@ -88,6 +123,13 @@ pub struct Swap {
     pub status: SwapStatus,
     pub decryption_key: Option<Bytes>,
     pub confirmed_at_ledger: Option<u32>,
+    /// Ledger timestamp at which the escrow hold period ends. Captured at
+    /// confirm time so it cannot be altered afterwards. `None` means no hold
+    /// applies (the feature was disabled for this swap's seller).
+    pub hold_until: Option<u64>,
+    /// Set to `true` when the buyer calls `confirm_receipt`, allowing the seller
+    /// to release funds before the hold period elapses.
+    pub buyer_confirmed: bool,
 }
 
 #[contracttype]
@@ -102,6 +144,8 @@ pub enum DataKey {
     Paused,
     DisputeWindowLedgers,
     AllowedToken(Address),
+    /// Per-seller escrow hold period override, in seconds.
+    SellerHoldPeriod(Address),
 }
 
 /// Event lifecycle:
@@ -176,6 +220,32 @@ pub struct AdminTransferred {
     #[topic]
     pub old_admin: Address,
     pub new_admin: Address,
+}
+
+/// Emitted when a seller configures their escrow hold period.
+#[contractevent]
+pub struct SellerHoldPeriodUpdated {
+    #[topic]
+    pub seller: Address,
+    pub hold_period_secs: u64,
+}
+
+/// Emitted when the admin updates the global escrow hold configuration.
+#[contractevent]
+pub struct EscrowHoldConfigUpdated {
+    #[topic]
+    pub admin: Address,
+    pub enabled: bool,
+    pub default_hold_period_secs: u64,
+}
+
+/// Emitted when a buyer confirms receipt, overriding the remaining hold period.
+/// Provides an on-chain audit trail of early-release authorisations.
+#[contractevent]
+pub struct BuyerConfirmedReceipt {
+    #[topic]
+    pub swap_id: u64,
+    pub buyer: Address,
 }
 
 /// Emitted when a dispute is resolved by the admin.
@@ -355,6 +425,41 @@ impl AtomicSwap {
         let _validated_fee = Self::calculate_fee_amount(env, usdc_amount, fee_bps);
     }
 
+    /// Resolve the effective hold period (in seconds) that applies to `seller`.
+    ///
+    /// Resolution order:
+    ///   1. A per-seller override (`SellerHoldPeriod`) always wins, even when it
+    ///      is `0` — that lets a seller explicitly opt out of holding funds.
+    ///   2. Otherwise, the global default applies only when holds are enabled.
+    ///   3. When holds are globally disabled and the seller has no override, the
+    ///      period is `0` (no hold), preserving the original swap flow.
+    fn effective_hold_period(env: &Env, config: &Config, seller: &Address) -> u64 {
+        if let Some(secs) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u64>(&DataKey::SellerHoldPeriod(seller.clone()))
+        {
+            return secs;
+        }
+        if config.escrow_hold.enabled {
+            config.escrow_hold.default_hold_period_secs
+        } else {
+            0
+        }
+    }
+
+    /// Whether `swap` is still inside its escrow hold period. A buyer who has
+    /// confirmed receipt waives the remaining hold, so the funds are releasable.
+    fn is_hold_active(env: &Env, swap: &Swap) -> bool {
+        if swap.buyer_confirmed {
+            return false;
+        }
+        match swap.hold_until {
+            Some(hold_until) => env.ledger().timestamp() < hold_until,
+            None => false,
+        }
+    }
+
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -379,6 +484,13 @@ impl AtomicSwap {
             swap_expiry_secs,
             zk_verifier,
             ip_registry,
+            // Hold feature is opt-in: disabled globally by default so existing
+            // swap flows are unchanged until the admin enables it or a seller
+            // sets their own hold period.
+            escrow_hold: EscrowHoldConfig {
+                enabled: false,
+                default_hold_period_secs: DEFAULT_HOLD_PERIOD_SECS,
+            },
         };
         // Store Admin and Config in persistent storage instead of instance storage
         env.storage().persistent().set(&DataKey::Admin, &admin);
@@ -437,6 +549,95 @@ impl AtomicSwap {
             PERSISTENT_TTL_LEDGERS,
             PERSISTENT_TTL_LEDGERS,
         );
+    }
+
+    /// Admin: enable/disable escrow holds globally and set the default period.
+    ///
+    /// The default period is bounded by `MAX_HOLD_PERIOD_SECS` to prevent funds
+    /// from being locked for an unreasonable amount of time.
+    pub fn set_escrow_hold_config(env: Env, enabled: bool, default_hold_period_secs: u64) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotInitialized));
+        admin.require_auth();
+        if default_hold_period_secs > MAX_HOLD_PERIOD_SECS {
+            env.panic_with_error(ContractError::HoldPeriodTooLong);
+        }
+        let mut config: Config = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotInitialized));
+        config.escrow_hold = EscrowHoldConfig {
+            enabled,
+            default_hold_period_secs,
+        };
+        env.storage().persistent().set(&DataKey::Config, &config);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Config,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+        EscrowHoldConfigUpdated {
+            admin,
+            enabled,
+            default_hold_period_secs,
+        }
+        .publish(&env);
+    }
+
+    /// Seller: configure the escrow hold period (in seconds) applied to their
+    /// future confirmed swaps. Pass `0` to opt out of holding funds.
+    ///
+    /// Security: only the seller can set their own period, the value is bounded
+    /// by `MAX_HOLD_PERIOD_SECS`, and the resulting `hold_until` is snapshotted
+    /// at confirm time — a seller cannot retroactively shorten or extend the
+    /// hold on a swap that is already in progress.
+    pub fn set_seller_hold_period(env: Env, seller: Address, hold_period_secs: u64) {
+        seller.require_auth();
+        if hold_period_secs > MAX_HOLD_PERIOD_SECS {
+            env.panic_with_error(ContractError::HoldPeriodTooLong);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::SellerHoldPeriod(seller.clone()), &hold_period_secs);
+        env.storage().persistent().extend_ttl(
+            &DataKey::SellerHoldPeriod(seller.clone()),
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+        SellerHoldPeriodUpdated {
+            seller,
+            hold_period_secs,
+        }
+        .publish(&env);
+    }
+
+    /// Returns the effective hold period (in seconds) that would apply to a swap
+    /// confirmed by `seller` right now. `0` means no hold.
+    pub fn get_hold_period(env: Env, seller: Address) -> u64 {
+        let config: Config = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotInitialized));
+        Self::effective_hold_period(&env, &config, &seller)
+    }
+
+    /// Returns `true` if the swap's escrow hold period is still in force, i.e.
+    /// funds cannot yet be released to the seller. Returns `false` when there is
+    /// no hold, the hold has elapsed, or the buyer has confirmed receipt.
+    pub fn hold_period_active(env: Env, swap_id: u64) -> bool {
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, Swap>(&DataKey::Swap(swap_id))
+        {
+            Some(swap) => Self::is_hold_active(&env, &swap),
+            None => false,
+        }
     }
 
     pub fn update_config(env: Env, fee_bps: u32, fee_recipient: Address, cancel_delay_secs: u64) {
@@ -661,6 +862,8 @@ impl AtomicSwap {
                 status: SwapStatus::Pending,
                 decryption_key: None,
                 confirmed_at_ledger: None,
+                hold_until: None,
+                buyer_confirmed: false,
             },
         );
         env.storage()
@@ -772,6 +975,14 @@ impl AtomicSwap {
         swap.status = SwapStatus::Completed;
         swap.decryption_key = Some(decryption_key.clone());
         swap.confirmed_at_ledger = Some(env.ledger().sequence());
+        // Snapshot the hold deadline now so the seller cannot manipulate it later.
+        let hold_secs = Self::effective_hold_period(&env, &config, &swap.seller);
+        swap.hold_until = if hold_secs > 0 {
+            Some(env.ledger().timestamp().saturating_add(hold_secs))
+        } else {
+            None
+        };
+        swap.buyer_confirmed = false;
         env.storage().persistent().set(&key, &swap);
         env.storage()
             .persistent()
@@ -825,6 +1036,19 @@ impl AtomicSwap {
             }
             .publish(&env);
             panic_with_error!(&env, ContractError::DisputeWindowActive);
+        }
+
+        // Escrow hold period: funds stay locked until the hold elapses, unless the
+        // buyer has confirmed receipt (set via confirm_receipt). This is an
+        // independent gate layered on top of the dispute window.
+        if Self::is_hold_active(&env, &swap) {
+            SwapReleaseFailed {
+                swap_id,
+                error_code: ContractError::HoldPeriodActive as u32,
+                seller: swap.seller.clone(),
+            }
+            .publish(&env);
+            panic_with_error!(&env, ContractError::HoldPeriodActive);
         }
 
         let token_client = token::Client::new(&env, &swap.usdc_token);
@@ -883,6 +1107,40 @@ impl AtomicSwap {
         env.storage()
             .instance()
             .extend_ttl(PERSISTENT_TTL_LEDGERS, PERSISTENT_TTL_LEDGERS);
+    }
+
+    /// Buyer: confirm receipt of the delivered IP, waiving the remaining escrow
+    /// hold period so the seller may release funds immediately.
+    ///
+    /// This is the buyer-confirmation override: only the buyer can call it, and
+    /// it does not bypass the dispute window — the buyer keeps their dispute
+    /// rights, but voluntarily signals the goods were received.
+    pub fn confirm_receipt(env: Env, swap_id: u64) {
+        let key = DataKey::Swap(swap_id);
+        let mut swap: Swap = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapNotFound));
+        if swap.status != SwapStatus::Completed {
+            env.panic_with_error(ContractError::SwapNotCompleted);
+        }
+        swap.buyer.require_auth();
+
+        swap.buyer_confirmed = true;
+        env.storage().persistent().set(&key, &swap);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL_LEDGERS, PERSISTENT_TTL_LEDGERS);
+        env.storage()
+            .instance()
+            .extend_ttl(PERSISTENT_TTL_LEDGERS, PERSISTENT_TTL_LEDGERS);
+
+        BuyerConfirmedReceipt {
+            swap_id,
+            buyer: swap.buyer,
+        }
+        .publish(&env);
     }
 
     pub fn raise_dispute(env: Env, swap_id: u64) {
@@ -2761,6 +3019,10 @@ mod test {
                 swap_expiry_secs: 3600, // Default in initialize call
                 zk_verifier: zk_id,
                 ip_registry: registry_id,
+                escrow_hold: EscrowHoldConfig {
+                    enabled: false,
+                    default_hold_period_secs: DEFAULT_HOLD_PERIOD_SECS,
+                },
             })
         );
 
@@ -3745,5 +4007,276 @@ mod test {
         let usdc_client = token::Client::new(&env, &usdc_id);
         assert_eq!(usdc_client.balance(&contract_id), 0);
         assert_eq!(usdc_client.balance(&buyer), 1000);
+    }
+
+    // ── escrow hold period tests ──────────────────────────────────────────────
+
+    /// Set up an initiated (but not yet confirmed) swap with a working ZK
+    /// verifier. The dispute window is shortened to 10 ledgers so tests can
+    /// isolate the hold period from the dispute window. Returns the handles a
+    /// test needs to configure the hold, confirm, and release.
+    fn initiated_hold_swap<'a>(
+        env: &'a Env,
+    ) -> (
+        AtomicSwapClient<'a>,
+        Address, // buyer
+        Address, // seller
+        Address, // usdc_id
+        u64,     // swap_id
+        Bytes,   // decryption key
+        soroban_sdk::Vec<ProofNode>,
+    ) {
+        let buyer = Address::generate(env);
+        let seller = Address::generate(env);
+        let usdc_id = setup_usdc(env, &buyer, 500);
+        let (registry_id, listing_id) = setup_registry(env, &seller, 500);
+        let key_bytes = Bytes::from_slice(env, b"secret-key");
+        let (zk_id, proof_path) = setup_zk_verifier(env, &seller, listing_id, &key_bytes);
+
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(env, &contract_id);
+        client.initialize(
+            &Address::generate(env),
+            &0u32,
+            &Address::generate(env),
+            &60u64,
+            &3600u64,
+            &zk_id,
+            &registry_id,
+        );
+        client.add_allowed_token(&usdc_id);
+        token::Client::new(env, &usdc_id).approve(&buyer, &contract_id, &500i128, &200u32);
+        client.set_dispute_window(&10u32);
+        let swap_id = client.initiate_swap(&listing_id, &buyer, &seller, &usdc_id, &500);
+        (client, buyer, seller, usdc_id, swap_id, key_bytes, proof_path)
+    }
+
+    /// A seller-configured hold keeps funds locked even after the dispute window
+    /// elapses, until the hold period passes. This is the early-release guard.
+    #[test]
+    fn test_hold_period_blocks_release_until_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _buyer, seller, _usdc_id, swap_id, key, proof) = initiated_hold_swap(&env);
+
+        client.set_seller_hold_period(&seller, &DEFAULT_HOLD_PERIOD_SECS);
+        client.confirm_swap(&swap_id, &key, &proof);
+
+        // Move past the dispute window but stay within the hold period.
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        assert!(client.hold_period_active(&swap_id));
+        let blocked = client.try_release_to_seller(&swap_id);
+        assert_eq!(
+            blocked,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::HoldPeriodActive as u32
+            )))
+        );
+
+        // Advance the clock past the hold period; release now succeeds.
+        env.ledger()
+            .with_mut(|li| li.timestamp = li.timestamp.saturating_add(DEFAULT_HOLD_PERIOD_SECS + 1));
+        assert!(!client.hold_period_active(&swap_id));
+        client.release_to_seller(&swap_id);
+        assert_eq!(
+            client.get_swap_status(&swap_id),
+            Some(SwapStatus::ResolvedSeller)
+        );
+    }
+
+    /// Time-locked release accuracy: the hold is active strictly before
+    /// `hold_until` and inactive at/after it (exclusive lower bound).
+    #[test]
+    fn test_hold_period_boundary_is_exact() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let hold_secs = 1_000u64;
+        let (client, _buyer, seller, _usdc_id, swap_id, key, proof) = initiated_hold_swap(&env);
+
+        client.set_seller_hold_period(&seller, &hold_secs);
+        // Confirm at timestamp 0 so hold_until == hold_secs exactly.
+        client.confirm_swap(&swap_id, &key, &proof);
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.hold_until, Some(hold_secs));
+
+        // One second before expiry: still active.
+        env.ledger().with_mut(|li| li.timestamp = hold_secs - 1);
+        assert!(client.hold_period_active(&swap_id));
+        assert!(client.try_release_to_seller(&swap_id).is_err());
+
+        // Exactly at expiry: no longer active, release allowed.
+        env.ledger().with_mut(|li| li.timestamp = hold_secs);
+        assert!(!client.hold_period_active(&swap_id));
+        client.release_to_seller(&swap_id);
+        assert_eq!(
+            client.get_swap_status(&swap_id),
+            Some(SwapStatus::ResolvedSeller)
+        );
+    }
+
+    /// The buyer can confirm receipt to waive the remaining hold, letting the
+    /// seller release immediately even though the hold period has not elapsed.
+    #[test]
+    fn test_buyer_confirmation_overrides_hold() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, buyer, seller, usdc_id, swap_id, key, proof) = initiated_hold_swap(&env);
+
+        client.set_seller_hold_period(&seller, &DEFAULT_HOLD_PERIOD_SECS);
+        client.confirm_swap(&swap_id, &key, &proof);
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+
+        // Still inside the hold period.
+        assert!(client.hold_period_active(&swap_id));
+
+        // Buyer confirms receipt; hold is waived.
+        client.confirm_receipt(&swap_id);
+        assert!(!client.hold_period_active(&swap_id));
+
+        client.release_to_seller(&swap_id);
+        assert_eq!(
+            client.get_swap_status(&swap_id),
+            Some(SwapStatus::ResolvedSeller)
+        );
+        // Seller received the funds (fee 0, no royalty).
+        assert_eq!(token::Client::new(&env, &usdc_id).balance(&seller), 500);
+        let _ = buyer;
+    }
+
+    /// Only the buyer may confirm receipt — a third party cannot self-approve to
+    /// bypass the buyer's hold.
+    #[test]
+    fn test_confirm_receipt_requires_buyer_auth() {
+        let env = Env::default();
+        env.mock_all_auths(); // setup only
+        let (client, _buyer, seller, _usdc_id, swap_id, key, proof) = initiated_hold_swap(&env);
+        client.set_seller_hold_period(&seller, &DEFAULT_HOLD_PERIOD_SECS);
+        client.confirm_swap(&swap_id, &key, &proof);
+
+        // Clear blanket auth and attempt confirm_receipt as a third party.
+        let third_party = Address::generate(&env);
+        env.set_auths(&[]);
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &third_party,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "confirm_receipt",
+                args: (swap_id,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        assert!(
+            client.try_confirm_receipt(&swap_id).is_err(),
+            "a non-buyer must not be able to confirm receipt"
+        );
+    }
+
+    /// When holds are disabled globally and the seller set no override, swaps
+    /// carry no hold (backwards-compatible default).
+    #[test]
+    fn test_no_hold_when_disabled_and_no_override() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _buyer, seller, _usdc_id, swap_id, key, proof) = initiated_hold_swap(&env);
+
+        assert_eq!(client.get_hold_period(&seller), 0);
+        client.confirm_swap(&swap_id, &key, &proof);
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.hold_until, None);
+
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        assert!(!client.hold_period_active(&swap_id));
+        client.release_to_seller(&swap_id);
+        assert_eq!(
+            client.get_swap_status(&swap_id),
+            Some(SwapStatus::ResolvedSeller)
+        );
+    }
+
+    /// The global default hold applies to a seller without an explicit override.
+    #[test]
+    fn test_global_hold_applies_without_seller_override() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _buyer, seller, _usdc_id, swap_id, key, proof) = initiated_hold_swap(&env);
+
+        client.set_escrow_hold_config(&true, &500u64);
+        assert_eq!(client.get_hold_period(&seller), 500);
+
+        client.confirm_swap(&swap_id, &key, &proof);
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        assert!(client.hold_period_active(&swap_id));
+        assert!(client.try_release_to_seller(&swap_id).is_err());
+    }
+
+    /// A per-seller override (including `0` to opt out) takes precedence over the
+    /// global default.
+    #[test]
+    fn test_seller_override_takes_precedence() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _buyer, seller, _usdc_id, swap_id, key, proof) = initiated_hold_swap(&env);
+
+        client.set_escrow_hold_config(&true, &DEFAULT_HOLD_PERIOD_SECS);
+        // Seller opts out entirely.
+        client.set_seller_hold_period(&seller, &0u64);
+        assert_eq!(client.get_hold_period(&seller), 0);
+
+        client.confirm_swap(&swap_id, &key, &proof);
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.hold_until, None);
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        assert!(!client.hold_period_active(&swap_id));
+    }
+
+    /// Hold periods above the cap are rejected, preventing indefinite fund locks.
+    #[test]
+    fn test_set_seller_hold_period_rejects_too_long() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _buyer, seller, _usdc_id, _swap_id, _key, _proof) = initiated_hold_swap(&env);
+
+        let result = client.try_set_seller_hold_period(&seller, &(MAX_HOLD_PERIOD_SECS + 1));
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::HoldPeriodTooLong as u32
+            )))
+        );
+    }
+
+    /// The admin cannot set a global default above the cap either.
+    #[test]
+    fn test_set_escrow_hold_config_rejects_too_long() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _buyer, _seller, _usdc_id, _swap_id, _key, _proof) = initiated_hold_swap(&env);
+
+        let result = client.try_set_escrow_hold_config(&true, &(MAX_HOLD_PERIOD_SECS + 1));
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::HoldPeriodTooLong as u32
+            )))
+        );
+    }
+
+    /// confirm_receipt is only valid on a Completed swap.
+    #[test]
+    fn test_confirm_receipt_requires_completed_swap() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _buyer, _seller, _usdc_id, swap_id, _key, _proof) = initiated_hold_swap(&env);
+
+        // Swap is still Pending (not confirmed).
+        let result = client.try_confirm_receipt(&swap_id);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::SwapNotCompleted as u32
+            )))
+        );
     }
 }

--- a/contracts/atomic_swap/test_snapshots/test/test_initialize_twice_returns_already_initialized.1.json
+++ b/contracts/atomic_swap/test_snapshots/test/test_initialize_twice_returns_already_initialized.1.json
@@ -126,6 +126,31 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_hold"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "default_hold_period_secs"
+                          },
+                          "val": {
+                            "u64": "86400"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "fee_bps"
                     },
                     "val": {

--- a/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_accepts_exact_price.1.json
+++ b/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_accepts_exact_price.1.json
@@ -664,6 +664,31 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_hold"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "default_hold_period_secs"
+                          },
+                          "val": {
+                            "u64": "86400"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "fee_bps"
                     },
                     "val": {
@@ -819,6 +844,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "buyer_confirmed"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "confirmed_at_ledger"
                     },
                     "val": "void"
@@ -844,6 +877,12 @@
                     "val": {
                       "u64": "3600"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "hold_until"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {

--- a/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_accepts_overpayment.1.json
+++ b/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_accepts_overpayment.1.json
@@ -664,6 +664,31 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_hold"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "default_hold_period_secs"
+                          },
+                          "val": {
+                            "u64": "86400"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "fee_bps"
                     },
                     "val": {
@@ -819,6 +844,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "buyer_confirmed"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "confirmed_at_ledger"
                     },
                     "val": "void"
@@ -844,6 +877,12 @@
                     "val": {
                       "u64": "3600"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "hold_until"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {

--- a/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_allows_any_amount_when_price_is_zero.1.json
+++ b/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_allows_any_amount_when_price_is_zero.1.json
@@ -664,6 +664,31 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_hold"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "default_hold_period_secs"
+                          },
+                          "val": {
+                            "u64": "86400"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "fee_bps"
                     },
                     "val": {
@@ -819,6 +844,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "buyer_confirmed"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "confirmed_at_ledger"
                     },
                     "val": "void"
@@ -844,6 +877,12 @@
                     "val": {
                       "u64": "3600"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "hold_until"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {

--- a/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_rejects_underpayment.1.json
+++ b/contracts/atomic_swap/test_snapshots/test/test_initiate_swap_rejects_underpayment.1.json
@@ -534,6 +534,31 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_hold"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "default_hold_period_secs"
+                          },
+                          "val": {
+                            "u64": "86400"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "fee_bps"
                     },
                     "val": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,3 +79,75 @@ sequenceDiagram
     USDC-->>AtomicSwap: ok
     AtomicSwap-->>Buyer: ok (status → Cancelled)
 ```
+
+## Escrow Hold Period
+
+After a swap is completed (the seller submits the decryption key), the seller's
+payout can be held for an additional, **seller-configurable** window layered on
+top of the dispute window. This gives an honest buyer time to verify the
+delivered IP before funds move, and lets a reputable seller advertise a buyer
+protection window.
+
+### Economics & rationale
+
+- **Default: 24 hours** (`DEFAULT_HOLD_PERIOD_SECS = 86_400`). Applied when a
+  seller enables holds without choosing a custom value.
+- **Per-seller configuration.** A seller calls `set_seller_hold_period(seller,
+  secs)`. A value of `0` opts out entirely. Sellers competing for buyers can
+  offer a longer hold as a trust signal; sellers who want faster settlement can
+  shorten or disable it.
+- **Global default.** The admin may enable holds protocol-wide and set the
+  default via `set_escrow_hold_config(enabled, default_secs)`. A per-seller
+  override always wins over the global default.
+- **Buyer confirmation override.** Once satisfied, the buyer calls
+  `confirm_receipt(swap_id)` to waive the remaining hold, so the seller is paid
+  immediately. This keeps a cooperative buyer from needlessly delaying an
+  honest seller while still defaulting to buyer protection.
+
+### Security properties
+
+- **No manipulation after the fact.** `hold_until` is snapshotted at
+  `confirm_swap` time from the seller's then-current configuration. Changing the
+  per-seller or global setting afterwards cannot shorten or extend the hold on a
+  swap that is already in progress.
+- **Bounded duration.** Both setters reject values above
+  `MAX_HOLD_PERIOD_SECS = 2_592_000` (30 days), preventing a hold from locking
+  buyer funds indefinitely.
+- **Authorization.** Only the buyer can call `confirm_receipt`; only the seller
+  can set their own hold period; only the admin can change the global default.
+- **Independent gate.** `release_to_seller` enforces the hold (error
+  `HoldPeriodActive`) in addition to the dispute window — both must clear before
+  funds are released, unless the buyer has confirmed receipt.
+
+### Audit trail
+
+`SellerHoldPeriodUpdated`, `EscrowHoldConfigUpdated`, and `BuyerConfirmedReceipt`
+events provide an on-chain record of configuration changes and early-release
+authorizations. The `hold_period_active(swap_id)` view returns whether a swap's
+funds are currently time-locked, which the UI surfaces via `HoldPeriodDisplay`.
+
+```mermaid
+sequenceDiagram
+    actor Seller
+    actor Buyer
+    participant AtomicSwap as atomic_swap
+    participant USDC as USDC Token
+
+    Seller->>AtomicSwap: set_seller_hold_period(seller, 86400)
+    Note over AtomicSwap: bounded by MAX_HOLD_PERIOD_SECS
+
+    Seller->>AtomicSwap: confirm_swap(swap_id, key, proof)
+    Note over AtomicSwap: status → Completed; hold_until = now + hold_secs
+
+    alt Buyer confirms receipt early
+        Buyer->>AtomicSwap: confirm_receipt(swap_id)
+        Note over AtomicSwap: buyer_confirmed = true (hold waived)
+    else Hold period elapses
+        Note over AtomicSwap: ledger.timestamp >= hold_until
+    end
+
+    Seller->>AtomicSwap: release_to_seller(swap_id)
+    Note over AtomicSwap: requires dispute window cleared AND hold not active
+    AtomicSwap->>USDC: transfer(contract → seller, amount − fees)
+    AtomicSwap-->>Seller: ok (status → ResolvedSeller)
+```

--- a/frontend/src/components/HoldPeriodDisplay.css
+++ b/frontend/src/components/HoldPeriodDisplay.css
@@ -1,0 +1,67 @@
+.hold-period {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+}
+
+.hold-period__label {
+  font-weight: 500;
+}
+
+.hold-period__time {
+  font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas,
+    "Courier New", monospace;
+  font-weight: 600;
+}
+
+/* Active: funds are time-locked. */
+.hold-period--active {
+  background-color: hsl(217, 91%, 95%);
+  border: 1px solid hsl(217, 91%, 60%);
+}
+.hold-period--active .hold-period__label {
+  color: hsl(217, 91%, 35%);
+}
+.hold-period--active .hold-period__time {
+  color: hsl(217, 91%, 25%);
+}
+
+/* Released early by buyer confirmation. */
+.hold-period--released {
+  background-color: hsl(142, 71%, 95%);
+  border: 1px solid hsl(142, 71%, 45%);
+  color: hsl(142, 71%, 25%);
+}
+
+/* Hold period elapsed naturally. */
+.hold-period--elapsed {
+  background-color: hsl(220, 14%, 96%);
+  border: 1px solid hsl(220, 13%, 70%);
+  color: hsl(220, 9%, 35%);
+}
+
+@media (prefers-color-scheme: dark) {
+  .hold-period--active {
+    background-color: hsl(217, 91%, 15%);
+    border-color: hsl(217, 91%, 40%);
+  }
+  .hold-period--active .hold-period__label {
+    color: hsl(217, 91%, 75%);
+  }
+  .hold-period--active .hold-period__time {
+    color: hsl(217, 91%, 85%);
+  }
+  .hold-period--released {
+    background-color: hsl(142, 71%, 13%);
+    border-color: hsl(142, 71%, 35%);
+    color: hsl(142, 71%, 80%);
+  }
+  .hold-period--elapsed {
+    background-color: hsl(220, 14%, 18%);
+    border-color: hsl(220, 13%, 40%);
+    color: hsl(220, 9%, 75%);
+  }
+}

--- a/frontend/src/components/HoldPeriodDisplay.tsx
+++ b/frontend/src/components/HoldPeriodDisplay.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import "./HoldPeriodDisplay.css";
+
+interface HoldPeriodDisplayProps {
+  /** Unix timestamp (secs) when the hold ends, or null when no hold applies. */
+  holdUntil: number | null;
+  /** True once the buyer has confirmed receipt (waives the remaining hold). */
+  buyerConfirmed: boolean;
+  /** Swap status string from the contract (e.g. "Completed", "ResolvedSeller"). */
+  status: string;
+  /** Optional callback fired once the hold period expires. */
+  onExpired?: () => void;
+}
+
+function formatTimeRemaining(seconds: number): string {
+  if (seconds <= 0) return "0s";
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m ${secs}s`;
+  if (minutes > 0) return `${minutes}m ${secs}s`;
+  return `${secs}s`;
+}
+
+/**
+ * Shows the escrow hold-period status for a completed swap:
+ *  - "Held" with a live countdown while funds are time-locked,
+ *  - "Confirmed by buyer" when the buyer has released the hold early,
+ *  - "Hold elapsed" once the period has passed (funds are releasable).
+ *
+ * Renders nothing when the swap has no hold or is no longer in escrow.
+ */
+export function HoldPeriodDisplay({
+  holdUntil,
+  buyerConfirmed,
+  status,
+  onExpired,
+}: HoldPeriodDisplayProps) {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  const isActive =
+    status === "Completed" &&
+    !buyerConfirmed &&
+    holdUntil !== null &&
+    now < holdUntil;
+
+  useEffect(() => {
+    if (!isActive) return;
+    const id = setInterval(() => {
+      const t = Math.floor(Date.now() / 1000);
+      setNow(t);
+      if (holdUntil !== null && t >= holdUntil) {
+        onExpired?.();
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [isActive, holdUntil, onExpired]);
+
+  // No hold configured for this swap, or it has already settled.
+  if (holdUntil === null || status !== "Completed") return null;
+
+  if (buyerConfirmed) {
+    return (
+      <div className="hold-period hold-period--released" role="status">
+        <span className="hold-period__label">Escrow hold</span>
+        <span className="hold-period__state">Released — buyer confirmed</span>
+      </div>
+    );
+  }
+
+  const remaining = Math.max(0, holdUntil - now);
+  if (remaining <= 0) {
+    return (
+      <div className="hold-period hold-period--elapsed" role="status">
+        <span className="hold-period__label">Escrow hold</span>
+        <span className="hold-period__state">Elapsed — funds releasable</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="hold-period hold-period--active"
+      role="timer"
+      aria-label={`Escrow hold releases in ${formatTimeRemaining(remaining)}`}
+    >
+      <span className="hold-period__label">Escrow hold</span>
+      <span className="hold-period__time">{formatTimeRemaining(remaining)}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/SwapCard.tsx
+++ b/frontend/src/components/SwapCard.tsx
@@ -1,5 +1,6 @@
 import { CancelSwapButton } from "./CancelSwapButton";
 import { ConfirmSwapForm } from "./ConfirmSwapForm";
+import { HoldPeriodDisplay } from "./HoldPeriodDisplay";
 import type { Wallet } from "../lib/walletKit";
 import type { Swap } from "../hooks/useMySwaps";
 import "./SwapCard.css";
@@ -35,6 +36,12 @@ export function SwapCard({
         </span>
         <span className="swap-card__amount">{(swap.usdc_amount / Math.pow(10, USDC_DECIMALS)).toFixed(2)} USDC</span>
       </div>
+      <HoldPeriodDisplay
+        holdUntil={swap.hold_until}
+        buyerConfirmed={swap.buyer_confirmed}
+        status={swap.status}
+        onExpired={onSwapUpdated}
+      />
       {isBuyer && (
         <CancelSwapButton
           swap={swap}

--- a/frontend/src/hooks/useMySwaps.ts
+++ b/frontend/src/hooks/useMySwaps.ts
@@ -14,6 +14,10 @@ export interface Swap {
   expires_at: number;
   status: string;
   decryption_key: string | null;
+  /** Unix timestamp (secs) when the escrow hold period ends, or null if no hold applies. */
+  hold_until: number | null;
+  /** True once the buyer has confirmed receipt, waiving the remaining hold. */
+  buyer_confirmed: boolean;
 }
 
 export function useMySwaps(walletAddress: string | null) {

--- a/frontend/src/lib/contractClient.ts
+++ b/frontend/src/lib/contractClient.ts
@@ -98,6 +98,12 @@ function decodeSwapScVal(
     );
   }
 
+  // hold_until is Option<u64>: scValToNative returns null or BigInt.
+  const holdUntil =
+    native.hold_until === null || native.hold_until === undefined
+      ? null
+      : Number(native.hold_until);
+
   return {
     id: swapId,
     listing_id: Number(native.listing_id ?? 0),
@@ -109,6 +115,8 @@ function decodeSwapScVal(
     expires_at: Number(native.expires_at ?? 0),
     status,
     decryption_key: decryptionKey,
+    hold_until: holdUntil,
+    buyer_confirmed: Boolean(native.buyer_confirmed),
   };
 }
 

--- a/frontend/tests/SwapStatusDashboard.test.tsx
+++ b/frontend/tests/SwapStatusDashboard.test.tsx
@@ -30,6 +30,8 @@ const mockSwap = {
   expires_at: Math.floor(Date.now() / 1000) + 3600,
   status: "Pending",
   decryption_key: null,
+  hold_until: null,
+  buyer_confirmed: false,
 };
 
 describe("SwapStatusDashboard", () => {

--- a/frontend/tests/mocks/contractMocks.ts
+++ b/frontend/tests/mocks/contractMocks.ts
@@ -16,6 +16,8 @@ export const createMockSwap = (overrides?: Partial<Swap>): Swap => ({
   expires_at: Math.floor(Date.now() / 1000) + 3600,
   status: "Pending",
   decryption_key: null,
+  hold_until: null,
+  buyer_confirmed: false,
   ...overrides,
 });
 


### PR DESCRIPTION
closes #690

- Add EscrowHoldConfig to Config with default 24-hour hold (opt-in, disabled globally by default to preserve existing swap flows)
- Support per-seller hold periods via set_seller_hold_period and an admin global default via set_escrow_hold_config, bounded by a 30-day cap to prevent indefinite fund locks / hold manipulation
- Snapshot hold_until at confirm_swap time so it cannot be altered later
- Enforce hold_period_active gate in release_to_seller (independent of the dispute window) with HoldPeriodActive error
- Add buyer confirm_receipt override to waive the remaining hold
- Expose hold_period_active and get_hold_period views; emit SellerHoldPeriodUpdated, EscrowHoldConfigUpdated and BuyerConfirmedReceipt events as an audit trail
- Add HoldPeriodDisplay component with live expiration timer in swap UI
- Document hold period economics in docs/architecture.md
- Cover enforcement, early-release prevention, expiration boundary, buyer override and config bounds with tests