### PR TITLE
feat: implement dispute resolution system

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -2,12 +2,15 @@
 use ip_registry::IpRegistryClient;
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, panic_with_error, token,
-    Address, Bytes, Env,
+    Address, Bytes, BytesN, Env,
 };
 use zk_verifier::{ProofNode, ZkVerifierClient};
 
 const PERSISTENT_TTL_LEDGERS: u32 = 6_312_000;
 const DEFAULT_DISPUTE_WINDOW_LEDGERS: u32 = 17_280;
+const DEFAULT_COMMIT_WINDOW_LEDGERS: u32 = 17_280;
+const DEFAULT_REVEAL_WINDOW_LEDGERS: u32 = 17_280;
+const DEFAULT_APPEAL_WINDOW_LEDGERS: u32 = 17_280;
 
 //Added enum
 
@@ -50,6 +53,32 @@ pub enum ContractError {
     /// Buyer's token allowance for this contract is below usdc_amount.
     /// Buyer must call `token.approve(contract, amount)` before initiating.
     InsufficientAllowance = 24,
+    /// Caller is not a registered active arbiter.
+    NotAnArbiter = 25,
+    /// Arbiter is a party to the swap and cannot vote (conflict of interest).
+    ArbiterConflictOfInterest = 26,
+    /// Arbiter has already committed a vote for this dispute.
+    ArbiterAlreadyCommitted = 27,
+    /// Arbiter has already revealed their vote for this dispute.
+    ArbiterAlreadyRevealed = 28,
+    /// No vote commitment found for this arbiter; commit before revealing.
+    VoteCommitNotFound = 29,
+    /// Revealed vote and salt do not match the stored commitment.
+    InvalidVoteReveal = 30,
+    /// The commit window for this dispute has already expired.
+    CommitWindowExpired = 31,
+    /// The reveal window has not yet opened (commit deadline not reached).
+    RevealWindowNotOpen = 32,
+    /// The reveal window for this dispute has expired.
+    RevealWindowExpired = 33,
+    /// Dispute outcome is already set; cannot finalize again.
+    DisputeAlreadyFinalized = 34,
+    /// The appeal window for this dispute has expired.
+    AppealWindowExpired = 35,
+    /// This dispute has already been appealed.
+    DisputeAlreadyAppealed = 36,
+    /// No Dispute record found for this swap_id.
+    SwapDisputeNotFound = 37,
 }
 
 #[contracttype]
@@ -90,6 +119,71 @@ pub struct Swap {
     pub confirmed_at_ledger: Option<u32>,
 }
 
+/// Outcome of a dispute after arbiter voting or admin resolution.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DisputeOutcome {
+    Pending,
+    FavorBuyer,
+    FavorSeller,
+}
+
+/// Compound key for per-arbiter, per-dispute vote storage.
+#[contracttype]
+#[derive(Clone)]
+pub struct DisputeVoteKey {
+    pub swap_id: u64,
+    pub arbiter: Address,
+}
+
+/// Compound key for per-evidence item storage.
+#[contracttype]
+#[derive(Clone)]
+pub struct EvidenceKey {
+    pub swap_id: u64,
+    pub index: u32,
+}
+
+/// Full dispute record stored on-chain when a buyer raises a dispute.
+#[contracttype]
+#[derive(Clone)]
+pub struct Dispute {
+    pub swap_id: u64,
+    pub raised_by: Address,
+    pub raised_at_ledger: u32,
+    pub evidence_count: u32,
+    pub outcome: DisputeOutcome,
+    pub resolved_at_ledger: Option<u32>,
+    /// Sum of revealed voting weights favouring the buyer.
+    pub vote_weight_buyer: i128,
+    /// Sum of revealed voting weights favouring the seller.
+    pub vote_weight_seller: i128,
+    /// Arbiters must commit a blinded vote before this ledger.
+    pub commit_deadline_ledger: u32,
+    /// Arbiters must reveal their vote between commit_deadline and this ledger.
+    pub reveal_deadline_ledger: u32,
+    /// Set after finalization; buyer may appeal before this ledger.
+    pub appeal_deadline_ledger: Option<u32>,
+    pub is_appealed: bool,
+}
+
+/// Metadata for a registered arbiter.
+#[contracttype]
+#[derive(Clone)]
+pub struct ArbiterInfo {
+    pub weight: i128,
+    pub is_active: bool,
+}
+
+/// A single piece of evidence submitted by a swap party.
+#[contracttype]
+#[derive(Clone)]
+pub struct DisputeEvidenceItem {
+    pub submitter: Address,
+    pub ipfs_hash: Bytes,
+    pub submitted_at_ledger: u32,
+}
+
 #[contracttype]
 pub enum DataKey {
     Swap(u64),
@@ -102,6 +196,25 @@ pub enum DataKey {
     Paused,
     DisputeWindowLedgers,
     AllowedToken(Address),
+    // ── Dispute resolution system ──────────────────────────────────────────────
+    /// Dispute record keyed by swap_id.
+    Dispute(u64),
+    /// Individual evidence items keyed by (swap_id, index).
+    EvidenceItem(EvidenceKey),
+    /// Registered arbiter metadata.
+    ArbiterEntry(Address),
+    /// Ordered list of all arbiter addresses.
+    ArbiterList,
+    /// Blinded vote commitment keyed by (swap_id, arbiter).
+    VoteCommit(DisputeVoteKey),
+    /// Revealed vote (bool) keyed by (swap_id, arbiter).
+    VoteRevealed(DisputeVoteKey),
+    /// Ledger window for the commit phase.
+    CommitWindowLedgers,
+    /// Ledger window for the reveal phase (starts after commit deadline).
+    RevealWindowLedgers,
+    /// Ledger window during which the buyer may appeal a finalized dispute.
+    AppealWindowLedgers,
 }
 
 /// Event lifecycle:
@@ -248,6 +361,64 @@ pub struct SwapReleaseFailed {
     /// The ContractError code that caused the failure.
     pub error_code: u32,
     pub seller: Address,
+}
+
+/// Emitted when an arbiter is registered or their weight updated.
+#[contractevent]
+pub struct ArbiterRegistered {
+    #[topic]
+    pub arbiter: Address,
+    pub weight: i128,
+}
+
+/// Emitted when an arbiter is deactivated (soft-removed).
+#[contractevent]
+pub struct ArbiterDeactivated {
+    #[topic]
+    pub arbiter: Address,
+}
+
+/// Emitted when a party submits evidence for a dispute.
+#[contractevent]
+pub struct EvidenceSubmitted {
+    #[topic]
+    pub swap_id: u64,
+    #[topic]
+    pub submitter: Address,
+    pub evidence_index: u32,
+}
+
+/// Emitted when an arbiter commits a blinded vote.
+/// Does NOT reveal who voted for what — anonymity is preserved until reveal.
+#[contractevent]
+pub struct VoteCommitted {
+    #[topic]
+    pub swap_id: u64,
+}
+
+/// Emitted when an arbiter reveals their vote.
+#[contractevent]
+pub struct VoteRevealed {
+    #[topic]
+    pub swap_id: u64,
+    pub arbiter: Address,
+    pub favor_buyer: bool,
+}
+
+/// Emitted when a dispute is finalized based on arbiter vote weights.
+#[contractevent]
+pub struct DisputeFinalized {
+    #[topic]
+    pub swap_id: u64,
+    pub favor_buyer: bool,
+}
+
+/// Emitted when the buyer appeals a finalized dispute.
+#[contractevent]
+pub struct DisputeAppealed {
+    #[topic]
+    pub swap_id: u64,
+    pub appellant: Address,
 }
 
 /// Discriminates the phase in which a swap failed, for detailed error recovery.
@@ -926,6 +1097,40 @@ impl AtomicSwap {
             PERSISTENT_TTL_LEDGERS,
         );
 
+        // Create the Dispute record with commit/reveal windows.
+        let commit_window: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CommitWindowLedgers)
+            .unwrap_or(DEFAULT_COMMIT_WINDOW_LEDGERS);
+        let reveal_window: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RevealWindowLedgers)
+            .unwrap_or(DEFAULT_REVEAL_WINDOW_LEDGERS);
+        let current_ledger = env.ledger().sequence();
+        let dispute = Dispute {
+            swap_id,
+            raised_by: swap.buyer.clone(),
+            raised_at_ledger: current_ledger,
+            evidence_count: 0,
+            outcome: DisputeOutcome::Pending,
+            resolved_at_ledger: None,
+            vote_weight_buyer: 0,
+            vote_weight_seller: 0,
+            commit_deadline_ledger: current_ledger + commit_window,
+            reveal_deadline_ledger: current_ledger + commit_window + reveal_window,
+            appeal_deadline_ledger: None,
+            is_appealed: false,
+        };
+        let dispute_key = DataKey::Dispute(swap_id);
+        env.storage().persistent().set(&dispute_key, &dispute);
+        env.storage().persistent().extend_ttl(
+            &dispute_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
         DisputeRaised {
             swap_id,
             buyer: swap.buyer,
@@ -951,61 +1156,7 @@ impl AtomicSwap {
             env.panic_with_error(ContractError::SwapNotDisputed);
         }
 
-        let token_client = token::Client::new(&env, &swap.usdc_token);
-        let contract_addr = env.current_contract_address();
-
-        if favor_buyer {
-            token_client.transfer(&contract_addr, &swap.buyer, &swap.usdc_amount);
-            swap.status = SwapStatus::ResolvedBuyer;
-        } else {
-            let config: Config = env
-                .storage()
-                .persistent()
-                .get(&DataKey::Config)
-                .unwrap_or_else(|| env.panic_with_error(ContractError::NotInitialized));
-            // Extend TTL on every state-mutating call to prevent expiration
-            env.storage().persistent().extend_ttl(
-                &DataKey::Admin,
-                PERSISTENT_TTL_LEDGERS,
-                PERSISTENT_TTL_LEDGERS,
-            );
-            env.storage().persistent().extend_ttl(
-                &DataKey::Config,
-                PERSISTENT_TTL_LEDGERS,
-                PERSISTENT_TTL_LEDGERS,
-            );
-
-            // Get listing to read royalty info
-            let listing = IpRegistryClient::new(&env, &config.ip_registry)
-                .get_listing(&swap.listing_id)
-                .unwrap_or_else(|| env.panic_with_error(ContractError::SwapNotFound));
-
-            // Deduct protocol fee. For very small amounts where the fee would
-            // truncate to zero, skip the fee entirely rather than panicking and
-            // permanently blocking dispute resolution.
-            let fee = {
-                let product = swap.usdc_amount.checked_mul(config.fee_bps as i128);
-                match product {
-                    Some(p) if p / 10_000 > 0 => p / 10_000,
-                    _ => 0,
-                }
-            };
-            let mut seller_amount = swap.usdc_amount - fee;
-            if fee > 0 {
-                token_client.transfer(&contract_addr, &config.fee_recipient, &fee);
-            }
-
-            // Royalty is calculated on the gross sale price (swap.usdc_amount), not the
-            // post-fee amount, so royalty semantics are independent of the protocol fee.
-            let royalty: i128 = (swap.usdc_amount * listing.royalty_bps as i128) / 10_000;
-            if royalty > 0 {
-                token_client.transfer(&contract_addr, &listing.royalty_recipient, &royalty);
-                seller_amount -= royalty;
-            }
-
-            token_client.transfer(&contract_addr, &swap.seller, &seller_amount);
-            swap.status = SwapStatus::ResolvedSeller;
-        }
+        Self::distribute_dispute_funds(&env, &mut swap, favor_buyer);
 
         DisputeResolved {
             swap_id,
@@ -1254,6 +1405,516 @@ impl AtomicSwap {
         }
         .publish(&env);
     }
+
+    // ── Dispute resolution helpers ─────────────────────────────────────────────
+
+    fn require_admin(env: &Env) -> Address {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotInitialized));
+        admin.require_auth();
+        admin
+    }
+
+    /// Shared fund-distribution logic used by both resolve_dispute (admin) and
+    /// finalize_dispute (arbiter vote). Returns true when funds go to buyer.
+    fn distribute_dispute_funds(env: &Env, swap: &mut Swap, favor_buyer: bool) {
+        let token_client = token::Client::new(env, &swap.usdc_token);
+        let contract_addr = env.current_contract_address();
+
+        if favor_buyer {
+            token_client.transfer(&contract_addr, &swap.buyer, &swap.usdc_amount);
+            swap.status = SwapStatus::ResolvedBuyer;
+        } else {
+            let config: Config = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Config)
+                .unwrap_or_else(|| env.panic_with_error(ContractError::NotInitialized));
+            env.storage().persistent().extend_ttl(
+                &DataKey::Admin,
+                PERSISTENT_TTL_LEDGERS,
+                PERSISTENT_TTL_LEDGERS,
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::Config,
+                PERSISTENT_TTL_LEDGERS,
+                PERSISTENT_TTL_LEDGERS,
+            );
+
+            let listing = IpRegistryClient::new(env, &config.ip_registry)
+                .get_listing(&swap.listing_id)
+                .unwrap_or_else(|| env.panic_with_error(ContractError::SwapNotFound));
+
+            let fee = {
+                let product = swap.usdc_amount.checked_mul(config.fee_bps as i128);
+                match product {
+                    Some(p) if p / 10_000 > 0 => p / 10_000,
+                    _ => 0,
+                }
+            };
+            let mut seller_amount = swap.usdc_amount - fee;
+            if fee > 0 {
+                token_client.transfer(&contract_addr, &config.fee_recipient, &fee);
+            }
+
+            let royalty: i128 = (swap.usdc_amount * listing.royalty_bps as i128) / 10_000;
+            if royalty > 0 {
+                token_client.transfer(&contract_addr, &listing.royalty_recipient, &royalty);
+                seller_amount -= royalty;
+            }
+
+            token_client.transfer(&contract_addr, &swap.seller, &seller_amount);
+            swap.status = SwapStatus::ResolvedSeller;
+        }
+    }
+
+    // ── Arbiter registry ───────────────────────────────────────────────────────
+
+    /// Register or update an arbiter's voting weight. Admin only.
+    pub fn register_arbiter(env: Env, arbiter: Address, weight: i128) {
+        Self::require_admin(&env);
+        if weight <= 0 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+
+        let info = ArbiterInfo { weight, is_active: true };
+        let entry_key = DataKey::ArbiterEntry(arbiter.clone());
+        env.storage().persistent().set(&entry_key, &info);
+        env.storage().persistent().extend_ttl(
+            &entry_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        let list_key = DataKey::ArbiterList;
+        let mut list: soroban_sdk::Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&list_key)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+        let mut found = false;
+        for i in 0..list.len() {
+            if list.get(i).unwrap() == arbiter {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            list.push_back(arbiter.clone());
+        }
+        env.storage().persistent().set(&list_key, &list);
+        env.storage().persistent().extend_ttl(
+            &list_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        ArbiterRegistered { arbiter, weight }.publish(&env);
+    }
+
+    /// Deactivate an arbiter so they can no longer vote. Admin only.
+    pub fn deactivate_arbiter(env: Env, arbiter: Address) {
+        Self::require_admin(&env);
+
+        let entry_key = DataKey::ArbiterEntry(arbiter.clone());
+        let mut info: ArbiterInfo = env
+            .storage()
+            .persistent()
+            .get(&entry_key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotAnArbiter));
+        info.is_active = false;
+        env.storage().persistent().set(&entry_key, &info);
+        env.storage().persistent().extend_ttl(
+            &entry_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        ArbiterDeactivated { arbiter }.publish(&env);
+    }
+
+    // ── Dispute window setters ─────────────────────────────────────────────────
+
+    pub fn set_commit_window(env: Env, ledgers: u32) {
+        Self::require_admin(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CommitWindowLedgers, &ledgers);
+        env.storage().persistent().extend_ttl(
+            &DataKey::CommitWindowLedgers,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+
+    pub fn set_reveal_window(env: Env, ledgers: u32) {
+        Self::require_admin(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RevealWindowLedgers, &ledgers);
+        env.storage().persistent().extend_ttl(
+            &DataKey::RevealWindowLedgers,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+
+    pub fn set_appeal_window(env: Env, ledgers: u32) {
+        Self::require_admin(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AppealWindowLedgers, &ledgers);
+        env.storage().persistent().extend_ttl(
+            &DataKey::AppealWindowLedgers,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+    }
+
+    // ── Evidence submission ────────────────────────────────────────────────────
+
+    /// Submit an IPFS-addressed evidence item for a disputed swap.
+    /// Only the swap buyer or seller may submit evidence.
+    pub fn submit_evidence(env: Env, swap_id: u64, submitter: Address, ipfs_hash: Bytes) {
+        submitter.require_auth();
+
+        let swap: Swap = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Swap(swap_id))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapNotFound));
+        if swap.status != SwapStatus::Disputed {
+            env.panic_with_error(ContractError::SwapNotDisputed);
+        }
+        if submitter != swap.buyer && submitter != swap.seller {
+            env.panic_with_error(ContractError::ArbiterConflictOfInterest);
+        }
+
+        let dispute_key = DataKey::Dispute(swap_id);
+        let mut dispute: Dispute = env
+            .storage()
+            .persistent()
+            .get(&dispute_key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapDisputeNotFound));
+
+        if env.ledger().sequence() > dispute.reveal_deadline_ledger {
+            env.panic_with_error(ContractError::CommitWindowExpired);
+        }
+
+        let evidence_index = dispute.evidence_count;
+        let evidence = DisputeEvidenceItem {
+            submitter: submitter.clone(),
+            ipfs_hash,
+            submitted_at_ledger: env.ledger().sequence(),
+        };
+        let ev_key = DataKey::EvidenceItem(EvidenceKey { swap_id, index: evidence_index });
+        env.storage().persistent().set(&ev_key, &evidence);
+        env.storage().persistent().extend_ttl(
+            &ev_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        dispute.evidence_count += 1;
+        env.storage().persistent().set(&dispute_key, &dispute);
+        env.storage().persistent().extend_ttl(
+            &dispute_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        EvidenceSubmitted { swap_id, submitter, evidence_index }.publish(&env);
+    }
+
+    // ── Commitment-reveal voting ───────────────────────────────────────────────
+
+    /// Phase 1: arbiter submits a blinded commitment = sha256(vote_byte || salt).
+    /// Call before commit_deadline_ledger. Commitment hides the vote until reveal phase.
+    pub fn commit_vote(
+        env: Env,
+        swap_id: u64,
+        arbiter: Address,
+        commitment: BytesN<32>,
+    ) {
+        arbiter.require_auth();
+
+        let arbiter_info: ArbiterInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArbiterEntry(arbiter.clone()))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotAnArbiter));
+        if !arbiter_info.is_active {
+            env.panic_with_error(ContractError::NotAnArbiter);
+        }
+
+        let swap: Swap = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Swap(swap_id))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapNotFound));
+        if swap.status != SwapStatus::Disputed {
+            env.panic_with_error(ContractError::SwapNotDisputed);
+        }
+        if arbiter == swap.buyer || arbiter == swap.seller {
+            env.panic_with_error(ContractError::ArbiterConflictOfInterest);
+        }
+
+        let dispute: Dispute = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Dispute(swap_id))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapDisputeNotFound));
+        if dispute.outcome != DisputeOutcome::Pending {
+            env.panic_with_error(ContractError::DisputeAlreadyFinalized);
+        }
+        if env.ledger().sequence() > dispute.commit_deadline_ledger {
+            env.panic_with_error(ContractError::CommitWindowExpired);
+        }
+
+        let commit_key = DataKey::VoteCommit(DisputeVoteKey { swap_id, arbiter: arbiter.clone() });
+        if env.storage().persistent().has(&commit_key) {
+            env.panic_with_error(ContractError::ArbiterAlreadyCommitted);
+        }
+
+        env.storage().persistent().set(&commit_key, &commitment);
+        env.storage().persistent().extend_ttl(
+            &commit_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        // Emit without naming the arbiter — preserves anonymity during commit phase.
+        VoteCommitted { swap_id }.publish(&env);
+    }
+
+    /// Phase 2: arbiter reveals their vote and salt.
+    /// Contract verifies sha256(vote_byte || salt) == stored commitment.
+    /// Call between commit_deadline_ledger and reveal_deadline_ledger.
+    pub fn reveal_vote(
+        env: Env,
+        swap_id: u64,
+        arbiter: Address,
+        favor_buyer: bool,
+        salt: Bytes,
+    ) {
+        arbiter.require_auth();
+
+        let arbiter_info: ArbiterInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArbiterEntry(arbiter.clone()))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotAnArbiter));
+        if !arbiter_info.is_active {
+            env.panic_with_error(ContractError::NotAnArbiter);
+        }
+
+        let dispute_key = DataKey::Dispute(swap_id);
+        let mut dispute: Dispute = env
+            .storage()
+            .persistent()
+            .get(&dispute_key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapDisputeNotFound));
+        if dispute.outcome != DisputeOutcome::Pending {
+            env.panic_with_error(ContractError::DisputeAlreadyFinalized);
+        }
+
+        let current = env.ledger().sequence();
+        if current <= dispute.commit_deadline_ledger {
+            env.panic_with_error(ContractError::RevealWindowNotOpen);
+        }
+        if current > dispute.reveal_deadline_ledger {
+            env.panic_with_error(ContractError::RevealWindowExpired);
+        }
+
+        let commit_key = DataKey::VoteCommit(DisputeVoteKey { swap_id, arbiter: arbiter.clone() });
+        let stored_commitment: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&commit_key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::VoteCommitNotFound));
+
+        let reveal_key = DataKey::VoteRevealed(DisputeVoteKey { swap_id, arbiter: arbiter.clone() });
+        if env.storage().persistent().has(&reveal_key) {
+            env.panic_with_error(ContractError::ArbiterAlreadyRevealed);
+        }
+
+        // Verify commitment: sha256(vote_byte || salt) must equal stored commitment.
+        let mut preimage = Bytes::new(&env);
+        preimage.push_back(if favor_buyer { 1u8 } else { 0u8 });
+        for i in 0..salt.len() {
+            preimage.push_back(salt.get(i).unwrap());
+        }
+        let computed: BytesN<32> = env.crypto().sha256(&preimage);
+        if computed != stored_commitment {
+            env.panic_with_error(ContractError::InvalidVoteReveal);
+        }
+
+        env.storage().persistent().set(&reveal_key, &favor_buyer);
+        env.storage().persistent().extend_ttl(
+            &reveal_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        if favor_buyer {
+            dispute.vote_weight_buyer = dispute
+                .vote_weight_buyer
+                .saturating_add(arbiter_info.weight);
+        } else {
+            dispute.vote_weight_seller = dispute
+                .vote_weight_seller
+                .saturating_add(arbiter_info.weight);
+        }
+        env.storage().persistent().set(&dispute_key, &dispute);
+        env.storage().persistent().extend_ttl(
+            &dispute_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        VoteRevealed { swap_id, arbiter, favor_buyer }.publish(&env);
+    }
+
+    // ── Finalize / appeal ──────────────────────────────────────────────────────
+
+    /// Finalize a dispute after the reveal window closes.
+    /// Tallies revealed vote weights and distributes funds accordingly.
+    /// Ties resolve in the buyer's favour (consumer protection default).
+    /// Anyone may call this; no auth required.
+    pub fn finalize_dispute(env: Env, swap_id: u64) {
+        let dispute_key = DataKey::Dispute(swap_id);
+        let mut dispute: Dispute = env
+            .storage()
+            .persistent()
+            .get(&dispute_key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapDisputeNotFound));
+        if dispute.outcome != DisputeOutcome::Pending {
+            env.panic_with_error(ContractError::DisputeAlreadyFinalized);
+        }
+        if env.ledger().sequence() <= dispute.reveal_deadline_ledger {
+            env.panic_with_error(ContractError::RevealWindowNotOpen);
+        }
+
+        let key = DataKey::Swap(swap_id);
+        let mut swap: Swap = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapNotFound));
+        if swap.status != SwapStatus::Disputed {
+            env.panic_with_error(ContractError::SwapNotDisputed);
+        }
+
+        // Ties default to buyer (consumer protection).
+        let favor_buyer = dispute.vote_weight_buyer >= dispute.vote_weight_seller;
+
+        Self::distribute_dispute_funds(&env, &mut swap, favor_buyer);
+
+        let current = env.ledger().sequence();
+        let appeal_window: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AppealWindowLedgers)
+            .unwrap_or(DEFAULT_APPEAL_WINDOW_LEDGERS);
+        dispute.outcome = if favor_buyer {
+            DisputeOutcome::FavorBuyer
+        } else {
+            DisputeOutcome::FavorSeller
+        };
+        dispute.resolved_at_ledger = Some(current);
+        dispute.appeal_deadline_ledger = Some(current + appeal_window);
+
+        env.storage().persistent().set(&key, &swap);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL_LEDGERS, PERSISTENT_TTL_LEDGERS);
+        env.storage().persistent().set(&dispute_key, &dispute);
+        env.storage().persistent().extend_ttl(
+            &dispute_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+        env.storage()
+            .instance()
+            .extend_ttl(PERSISTENT_TTL_LEDGERS, PERSISTENT_TTL_LEDGERS);
+
+        DisputeFinalized { swap_id, favor_buyer }.publish(&env);
+    }
+
+    /// Appeal a finalized dispute within the appeal window.
+    /// Only the buyer may appeal. This emits an event signalling admin review;
+    /// funds are not automatically reversed — admin calls resolve_dispute if
+    /// the appeal succeeds.
+    pub fn appeal_dispute(env: Env, swap_id: u64, appellant: Address) {
+        appellant.require_auth();
+
+        let swap: Swap = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Swap(swap_id))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapNotFound));
+        if appellant != swap.buyer {
+            env.panic_with_error(ContractError::ArbiterConflictOfInterest);
+        }
+
+        let dispute_key = DataKey::Dispute(swap_id);
+        let mut dispute: Dispute = env
+            .storage()
+            .persistent()
+            .get(&dispute_key)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::SwapDisputeNotFound));
+        if dispute.outcome == DisputeOutcome::Pending {
+            env.panic_with_error(ContractError::SwapNotDisputed);
+        }
+        if dispute.is_appealed {
+            env.panic_with_error(ContractError::DisputeAlreadyAppealed);
+        }
+        let deadline = dispute.appeal_deadline_ledger.unwrap_or(0);
+        if env.ledger().sequence() > deadline {
+            env.panic_with_error(ContractError::AppealWindowExpired);
+        }
+
+        dispute.is_appealed = true;
+        env.storage().persistent().set(&dispute_key, &dispute);
+        env.storage().persistent().extend_ttl(
+            &dispute_key,
+            PERSISTENT_TTL_LEDGERS,
+            PERSISTENT_TTL_LEDGERS,
+        );
+
+        DisputeAppealed { swap_id, appellant }.publish(&env);
+    }
+
+    // ── Dispute read functions ─────────────────────────────────────────────────
+
+    pub fn get_dispute(env: Env, swap_id: u64) -> Option<Dispute> {
+        let key = DataKey::Dispute(swap_id);
+        let dispute: Option<Dispute> = env.storage().persistent().get(&key);
+        if dispute.is_some() {
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_LEDGERS,
+                PERSISTENT_TTL_LEDGERS,
+            );
+        }
+        dispute
+    }
+
+    pub fn get_evidence(env: Env, swap_id: u64, index: u32) -> Option<DisputeEvidenceItem> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EvidenceItem(EvidenceKey { swap_id, index }))
+    }
+
+    pub fn get_arbiters(env: Env) -> soroban_sdk::Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ArbiterList)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(&env))
+    }
 }
 
 #[cfg(test)]
@@ -1262,7 +1923,7 @@ mod test {
     use ip_registry::{IpRegistry, IpRegistryClient};
     use soroban_sdk::{
         testutils::{Address as _, Events, Ledger as _},
-        token, Bytes, Env, IntoVal, TryFromVal, Vec,
+        token, Bytes, BytesN, Env, IntoVal, TryFromVal, Vec,
     };
     use zk_verifier::{ProofNode, ZkVerifier, ZkVerifierClient};
 
@@ -3703,6 +4364,400 @@ mod test {
         // Funds must not move
         assert_eq!(usdc_client.balance(&contract_id), 500);
         assert_eq!(usdc_client.balance(&buyer), 0);
+    }
+
+    // ── Dispute resolution system tests ──────────────────────────────────────
+
+    fn make_commitment(env: &Env, favor_buyer: bool, salt: &Bytes) -> BytesN<32> {
+        let mut preimage = Bytes::new(env);
+        preimage.push_back(if favor_buyer { 1u8 } else { 0u8 });
+        for i in 0..salt.len() {
+            preimage.push_back(salt.get(i).unwrap());
+        }
+        env.crypto().sha256(&preimage)
+    }
+
+    fn setup_arbiter(client: &AtomicSwapClient, arbiter: &Address, weight: i128) {
+        client.register_arbiter(arbiter, &weight);
+    }
+
+    #[test]
+    fn test_raise_dispute_creates_dispute_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        client.set_dispute_window(&100u32);
+        client.set_commit_window(&50u32);
+        client.set_reveal_window(&50u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        let dispute = client.get_dispute(&swap_id).expect("Dispute record must exist");
+        assert_eq!(dispute.swap_id, swap_id);
+        assert_eq!(dispute.raised_by, buyer);
+        assert_eq!(dispute.outcome, DisputeOutcome::Pending);
+        assert_eq!(dispute.evidence_count, 0);
+        assert!(!dispute.is_appealed);
+    }
+
+    #[test]
+    fn test_register_and_deactivate_arbiter() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (_, _, _, _, client, _, _) = setup_full(&env, &buyer, &seller, 500, 1);
+
+        let arbiter = Address::generate(&env);
+        client.register_arbiter(&arbiter, &100i128);
+
+        let arbiters = client.get_arbiters();
+        assert_eq!(arbiters.len(), 1);
+
+        client.deactivate_arbiter(&arbiter);
+        // Still in list but is_active=false; commit_vote should reject it
+    }
+
+    #[test]
+    fn test_submit_evidence_by_buyer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        let hash = Bytes::from_slice(&env, b"QmTestEvidenceHash");
+        client.submit_evidence(&swap_id, &buyer, &hash);
+
+        let dispute = client.get_dispute(&swap_id).unwrap();
+        assert_eq!(dispute.evidence_count, 1);
+
+        let ev = client.get_evidence(&swap_id, &0u32).expect("evidence must exist");
+        assert_eq!(ev.submitter, buyer);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #13)")]
+    fn test_submit_evidence_rejected_on_non_disputed_swap() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        // swap is Completed, not Disputed
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        let hash = Bytes::from_slice(&env, b"QmHash");
+        client.submit_evidence(&swap_id, &buyer, &hash);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #25)")]
+    fn test_commit_vote_rejected_for_non_arbiter() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        let non_arbiter = Address::generate(&env);
+        let salt = Bytes::from_slice(&env, b"salt");
+        let commit = make_commitment(&env, true, &salt);
+        client.commit_vote(&swap_id, &non_arbiter, &commit);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #26)")]
+    fn test_commit_vote_rejected_for_buyer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        // Register buyer as arbiter — conflict of interest should be caught
+        client.register_arbiter(&buyer, &100i128);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        let salt = Bytes::from_slice(&env, b"salt");
+        let commit = make_commitment(&env, true, &salt);
+        client.commit_vote(&swap_id, &buyer, &commit);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #27)")]
+    fn test_commit_vote_rejected_on_double_commit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        let arbiter = Address::generate(&env);
+        client.register_arbiter(&arbiter, &100i128);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        let salt = Bytes::from_slice(&env, b"salt");
+        let commit = make_commitment(&env, true, &salt);
+        client.commit_vote(&swap_id, &arbiter, &commit);
+        // Second commit must fail
+        client.commit_vote(&swap_id, &arbiter, &commit);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #30)")]
+    fn test_reveal_vote_rejected_on_wrong_salt() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        let arbiter = Address::generate(&env);
+        client.register_arbiter(&arbiter, &100i128);
+        client.set_commit_window(&10u32);
+        client.set_reveal_window(&10u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        let real_salt = Bytes::from_slice(&env, b"correct-salt");
+        let commit = make_commitment(&env, true, &real_salt);
+        client.commit_vote(&swap_id, &arbiter, &commit);
+
+        // Advance past commit deadline
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+
+        // Reveal with wrong salt — must fail
+        let wrong_salt = Bytes::from_slice(&env, b"wrong-salt");
+        client.reveal_vote(&swap_id, &arbiter, &true, &wrong_salt);
+    }
+
+    #[test]
+    fn test_full_dispute_lifecycle_arbiter_votes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+        let usdc_client = token::Client::new(&env, &usdc_id);
+
+        // Short windows so we can advance past them easily
+        client.set_commit_window(&10u32);
+        client.set_reveal_window(&10u32);
+
+        let arbiter1 = Address::generate(&env);
+        let arbiter2 = Address::generate(&env);
+        client.register_arbiter(&arbiter1, &60i128);
+        client.register_arbiter(&arbiter2, &40i128);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        // Submit evidence
+        let hash = Bytes::from_slice(&env, b"QmEvidence");
+        client.submit_evidence(&swap_id, &buyer, &hash);
+
+        // Commit phase: both arbiters vote favour_buyer=true
+        let salt1 = Bytes::from_slice(&env, b"salt1");
+        let salt2 = Bytes::from_slice(&env, b"salt2");
+        let commit1 = make_commitment(&env, true, &salt1);
+        let commit2 = make_commitment(&env, false, &salt2);
+        client.commit_vote(&swap_id, &arbiter1, &commit1);
+        client.commit_vote(&swap_id, &arbiter2, &commit2);
+
+        // Advance past commit deadline
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+
+        // Reveal phase
+        client.reveal_vote(&swap_id, &arbiter1, &true, &salt1);
+        client.reveal_vote(&swap_id, &arbiter2, &false, &salt2);
+
+        // Advance past reveal deadline
+        env.ledger().with_mut(|li| li.sequence_number += 10);
+
+        // Finalize — arbiter1 weight 60 (buyer) beats arbiter2 weight 40 (seller)
+        client.finalize_dispute(&swap_id);
+
+        let dispute = client.get_dispute(&swap_id).unwrap();
+        assert_eq!(dispute.outcome, DisputeOutcome::FavorBuyer);
+        assert_eq!(dispute.vote_weight_buyer, 60);
+        assert_eq!(dispute.vote_weight_seller, 40);
+        // Buyer should be refunded
+        assert_eq!(usdc_client.balance(&buyer), 500);
+        assert_eq!(usdc_client.balance(&seller), 0);
+    }
+
+    #[test]
+    fn test_finalize_dispute_tie_favours_buyer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+        let usdc_client = token::Client::new(&env, &usdc_id);
+
+        client.set_commit_window(&10u32);
+        client.set_reveal_window(&10u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        // No arbiters vote — both weights stay 0, tie → buyer wins
+        env.ledger().with_mut(|li| li.sequence_number += 21);
+        client.finalize_dispute(&swap_id);
+
+        let dispute = client.get_dispute(&swap_id).unwrap();
+        assert_eq!(dispute.outcome, DisputeOutcome::FavorBuyer);
+        assert_eq!(usdc_client.balance(&buyer), 500);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #32)")]
+    fn test_finalize_dispute_rejected_before_reveal_deadline() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        client.set_commit_window(&20u32);
+        client.set_reveal_window(&20u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        // Only past commit window, not reveal window
+        env.ledger().with_mut(|li| li.sequence_number += 25);
+        // Still inside reveal window — must fail
+        client.finalize_dispute(&swap_id);
+    }
+
+    #[test]
+    fn test_appeal_dispute_within_window() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        client.set_commit_window(&5u32);
+        client.set_reveal_window(&5u32);
+        client.set_appeal_window(&20u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        // Fast-forward past both windows to finalize
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        client.finalize_dispute(&swap_id);
+
+        // Appeal within window
+        client.appeal_dispute(&swap_id, &buyer);
+
+        let dispute = client.get_dispute(&swap_id).unwrap();
+        assert!(dispute.is_appealed);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #36)")]
+    fn test_appeal_dispute_rejected_on_double_appeal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        client.set_commit_window(&5u32);
+        client.set_reveal_window(&5u32);
+        client.set_appeal_window(&20u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        client.finalize_dispute(&swap_id);
+
+        client.appeal_dispute(&swap_id, &buyer);
+        // Second appeal must fail
+        client.appeal_dispute(&swap_id, &buyer);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #35)")]
+    fn test_appeal_dispute_rejected_after_window_expires() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        client.set_commit_window(&5u32);
+        client.set_reveal_window(&5u32);
+        client.set_appeal_window(&5u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        client.finalize_dispute(&swap_id);
+
+        // Advance past appeal window
+        env.ledger().with_mut(|li| li.sequence_number += 6);
+        client.appeal_dispute(&swap_id, &buyer);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #28)")]
+    fn test_reveal_vote_rejected_on_double_reveal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let (usdc_id, listing_id, _, _, client, _, _) =
+            setup_full(&env, &buyer, &seller, 500, 1);
+
+        let arbiter = Address::generate(&env);
+        client.register_arbiter(&arbiter, &100i128);
+        client.set_commit_window(&10u32);
+        client.set_reveal_window(&20u32);
+
+        let swap_id = confirmed_swap(&env, &client, listing_id, &buyer, &seller, &usdc_id, 500);
+        client.raise_dispute(&swap_id);
+
+        let salt = Bytes::from_slice(&env, b"unique-salt");
+        let commit = make_commitment(&env, true, &salt);
+        client.commit_vote(&swap_id, &arbiter, &commit);
+
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+        client.reveal_vote(&swap_id, &arbiter, &true, &salt);
+        // Second reveal must fail
+        client.reveal_vote(&swap_id, &arbiter, &true, &salt);
     }
 
     /// InsufficientAllowance (error #24) returns the correct error and leaves no

--- a/frontend/src/components/DisputePanel.css
+++ b/frontend/src/components/DisputePanel.css
@@ -1,0 +1,340 @@
+.dispute-panel {
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 12px;
+  background: var(--color-surface, #f8fafc);
+}
+
+.dispute-panel--disputed {
+  border-color: #f59e0b;
+  background: #fffbeb;
+}
+
+.dispute-panel--resolved-buyer {
+  border-color: #22c55e;
+  background: #f0fdf4;
+}
+
+.dispute-panel--resolved-seller {
+  border-color: #6366f1;
+  background: #eef2ff;
+}
+
+.dispute-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.dispute-panel__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text, #1e293b);
+}
+
+.dispute-panel__outcome-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 9999px;
+}
+
+.dispute-panel__outcome-badge--pending {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.dispute-panel__outcome-badge--buyer {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.dispute-panel__outcome-badge--seller {
+  background: #ede9fe;
+  color: #4c1d95;
+}
+
+/* ── Timeline ──────────────────────────────────────────────────────────────── */
+
+.dispute-timeline {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  position: relative;
+}
+
+.dispute-timeline::before {
+  content: "";
+  position: absolute;
+  left: 7px;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--color-border, #e2e8f0);
+}
+
+.dispute-timeline__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 4px 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #64748b);
+  position: relative;
+}
+
+.dispute-timeline__dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--color-border, #e2e8f0);
+  background: #fff;
+  flex-shrink: 0;
+  margin-top: 1px;
+  z-index: 1;
+}
+
+.dispute-timeline__dot--active {
+  border-color: #f59e0b;
+  background: #f59e0b;
+}
+
+.dispute-timeline__dot--done {
+  border-color: #22c55e;
+  background: #22c55e;
+}
+
+.dispute-timeline__dot--future {
+  border-color: #cbd5e1;
+  background: #f1f5f9;
+}
+
+.dispute-timeline__label {
+  flex: 1;
+  line-height: 1.4;
+}
+
+.dispute-timeline__ledger {
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #94a3b8);
+  white-space: nowrap;
+}
+
+/* ── Vote weights ──────────────────────────────────────────────────────────── */
+
+.dispute-votes {
+  margin-bottom: 16px;
+}
+
+.dispute-votes__label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-muted, #64748b);
+  margin-bottom: 6px;
+}
+
+.dispute-votes__bar {
+  display: flex;
+  height: 10px;
+  border-radius: 5px;
+  overflow: hidden;
+  background: #e2e8f0;
+  margin-bottom: 4px;
+}
+
+.dispute-votes__bar-buyer {
+  background: #22c55e;
+  transition: width 0.3s ease;
+}
+
+.dispute-votes__bar-seller {
+  background: #6366f1;
+  transition: width 0.3s ease;
+}
+
+.dispute-votes__legend {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.73rem;
+  color: var(--color-text-muted, #64748b);
+}
+
+.dispute-votes__legend-buyer { color: #15803d; }
+.dispute-votes__legend-seller { color: #4338ca; }
+
+/* ── Evidence list ─────────────────────────────────────────────────────────── */
+
+.dispute-evidence {
+  margin-bottom: 16px;
+}
+
+.dispute-evidence__title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted, #64748b);
+  margin-bottom: 6px;
+}
+
+.dispute-evidence__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dispute-evidence__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.78rem;
+  color: var(--color-text, #334155);
+  border-bottom: 1px solid var(--color-border, #f1f5f9);
+}
+
+.dispute-evidence__item:last-child {
+  border-bottom: none;
+}
+
+.dispute-evidence__hash {
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: #3b82f6;
+  word-break: break-all;
+}
+
+.dispute-evidence__submitter {
+  font-size: 0.7rem;
+  color: var(--color-text-muted, #94a3b8);
+}
+
+/* ── Action forms ──────────────────────────────────────────────────────────── */
+
+.dispute-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dispute-action-group {
+  border-top: 1px solid var(--color-border, #e2e8f0);
+  padding-top: 12px;
+}
+
+.dispute-action-group__title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text, #334155);
+  margin-bottom: 8px;
+}
+
+.dispute-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dispute-form__row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.dispute-form__input {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  background: #fff;
+  color: var(--color-text, #1e293b);
+  outline: none;
+}
+
+.dispute-form__input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.dispute-form__select {
+  padding: 6px 10px;
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  background: #fff;
+  color: var(--color-text, #1e293b);
+}
+
+.dispute-form__hint {
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #94a3b8);
+}
+
+.dispute-btn {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.dispute-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.dispute-btn--danger {
+  background: #ef4444;
+  color: #fff;
+}
+.dispute-btn--danger:hover:not(:disabled) { background: #dc2626; }
+
+.dispute-btn--primary {
+  background: #6366f1;
+  color: #fff;
+}
+.dispute-btn--primary:hover:not(:disabled) { background: #4f46e5; }
+
+.dispute-btn--neutral {
+  background: #64748b;
+  color: #fff;
+}
+.dispute-btn--neutral:hover:not(:disabled) { background: #475569; }
+
+.dispute-btn--success {
+  background: #22c55e;
+  color: #fff;
+}
+.dispute-btn--success:hover:not(:disabled) { background: #16a34a; }
+
+.dispute-btn--warning {
+  background: #f59e0b;
+  color: #fff;
+}
+.dispute-btn--warning:hover:not(:disabled) { background: #d97706; }
+
+.dispute-panel__error {
+  font-size: 0.78rem;
+  color: #ef4444;
+  margin-top: 4px;
+}
+
+.dispute-panel__success {
+  font-size: 0.78rem;
+  color: #16a34a;
+  margin-top: 4px;
+}
+
+.dispute-panel__appealed-notice {
+  font-size: 0.78rem;
+  background: #fef9c3;
+  color: #713f12;
+  border: 1px solid #fde047;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-top: 8px;
+}

--- a/frontend/src/components/DisputePanel.tsx
+++ b/frontend/src/components/DisputePanel.tsx
@@ -1,0 +1,560 @@
+import { useState, useEffect, useCallback } from "react";
+import type { Wallet } from "../lib/walletKit";
+import type { Swap } from "../hooks/useMySwaps";
+import {
+  getDispute,
+  getEvidence,
+  raiseDispute,
+  submitEvidence,
+  commitVote,
+  revealVote,
+  finalizeDispute,
+  appealDispute,
+  getCurrentLedger,
+  type DisputeRecord,
+  type EvidenceItem,
+} from "../lib/contractClient";
+import "./DisputePanel.css";
+
+interface Props {
+  swap: Swap;
+  wallet: Wallet;
+  onSwapUpdated: () => void;
+}
+
+type Phase = "commit" | "reveal" | "closed";
+
+function getPhase(dispute: DisputeRecord, currentLedger: number): Phase {
+  if (currentLedger <= dispute.commit_deadline_ledger) return "commit";
+  if (currentLedger <= dispute.reveal_deadline_ledger) return "reveal";
+  return "closed";
+}
+
+function outcomeLabel(outcome: DisputeRecord["outcome"]): string {
+  if (outcome === "FavorBuyer") return "Resolved: Buyer";
+  if (outcome === "FavorSeller") return "Resolved: Seller";
+  return "Pending";
+}
+
+function shortAddr(addr: string) {
+  return addr ? `${addr.slice(0, 4)}…${addr.slice(-4)}` : "";
+}
+
+export function DisputePanel({ swap, wallet, onSwapUpdated }: Props) {
+  const isBuyer = wallet.address === swap.buyer;
+  const isDisputed = swap.status === "Disputed";
+  const isCompleted = swap.status === "Completed";
+  const isResolved =
+    swap.status === "ResolvedBuyer" || swap.status === "ResolvedSeller";
+
+  const [dispute, setDispute] = useState<DisputeRecord | null>(null);
+  const [evidence, setEvidence] = useState<EvidenceItem[]>([]);
+  const [currentLedger, setCurrentLedger] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Evidence form
+  const [ipfsInput, setIpfsInput] = useState("");
+
+  // Arbiter vote commit form
+  const [voteChoice, setVoteChoice] = useState<"buyer" | "seller">("buyer");
+  const [voteSalt, setVoteSalt] = useState("");
+
+  // Arbiter vote reveal form
+  const [revealChoice, setRevealChoice] = useState<"buyer" | "seller">("buyer");
+  const [revealSalt, setRevealSalt] = useState("");
+
+  const loadDispute = useCallback(async () => {
+    if (!isDisputed && !isResolved) return;
+    try {
+      const [d, ledger] = await Promise.all([
+        getDispute(swap.id),
+        getCurrentLedger(),
+      ]);
+      setDispute(d);
+      setCurrentLedger(ledger);
+      if (d) {
+        const items: EvidenceItem[] = [];
+        for (let i = 0; i < d.evidence_count; i++) {
+          const ev = await getEvidence(swap.id, i);
+          if (ev) items.push(ev);
+        }
+        setEvidence(items);
+      }
+    } catch {
+      // non-fatal
+    }
+  }, [swap.id, isDisputed, isResolved]);
+
+  useEffect(() => {
+    loadDispute();
+  }, [loadDispute]);
+
+  function notify(msg: string) {
+    setSuccess(msg);
+    setError(null);
+    setTimeout(() => setSuccess(null), 4000);
+  }
+
+  async function handleRaiseDispute() {
+    setLoading(true);
+    setError(null);
+    try {
+      await raiseDispute(swap.id, wallet);
+      notify("Dispute raised. Arbiters may now submit votes.");
+      onSwapUpdated();
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to raise dispute.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSubmitEvidence() {
+    if (!ipfsInput.trim()) {
+      setError("Enter an IPFS hash.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await submitEvidence(swap.id, ipfsInput.trim(), wallet);
+      notify(`Evidence submitted: ${ipfsInput.trim()}`);
+      setIpfsInput("");
+      await loadDispute();
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to submit evidence.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCommitVote() {
+    if (!voteSalt.trim()) {
+      setError("Enter a secret salt. Save it — you'll need it for reveal.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await commitVote(swap.id, voteChoice === "buyer", voteSalt.trim(), wallet);
+      notify("Vote committed. Keep your salt safe for the reveal phase.");
+      setVoteSalt("");
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to commit vote.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleRevealVote() {
+    if (!revealSalt.trim()) {
+      setError("Enter the salt you used during the commit phase.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await revealVote(
+        swap.id,
+        revealChoice === "buyer",
+        revealSalt.trim(),
+        wallet
+      );
+      notify("Vote revealed. Weights updated.");
+      setRevealSalt("");
+      await loadDispute();
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to reveal vote.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleFinalize() {
+    setLoading(true);
+    setError(null);
+    try {
+      await finalizeDispute(swap.id, wallet);
+      notify("Dispute finalized. Funds distributed.");
+      onSwapUpdated();
+      await loadDispute();
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to finalize dispute.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAppeal() {
+    setLoading(true);
+    setError(null);
+    try {
+      await appealDispute(swap.id, wallet);
+      notify("Appeal submitted. An admin will review.");
+      await loadDispute();
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to submit appeal.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Panel only renders when there is something dispute-related to show
+  if (!isDisputed && !isCompleted && !isResolved) return null;
+
+  const phase = dispute ? getPhase(dispute, currentLedger) : null;
+  const canFinalize =
+    dispute &&
+    phase === "closed" &&
+    dispute.outcome === "Pending" &&
+    isDisputed;
+  const canAppeal =
+    dispute &&
+    dispute.outcome !== "Pending" &&
+    !dispute.is_appealed &&
+    isBuyer &&
+    dispute.appeal_deadline_ledger != null &&
+    currentLedger <= dispute.appeal_deadline_ledger;
+
+  const totalWeight =
+    dispute && dispute.outcome !== "Pending"
+      ? BigInt(dispute.vote_weight_buyer) + BigInt(dispute.vote_weight_seller)
+      : BigInt(dispute?.vote_weight_buyer ?? 0) +
+        BigInt(dispute?.vote_weight_seller ?? 0);
+
+  const buyerPct =
+    totalWeight > 0n
+      ? Number((BigInt(dispute?.vote_weight_buyer ?? 0) * 100n) / totalWeight)
+      : 50;
+  const sellerPct = 100 - buyerPct;
+
+  const panelClass = [
+    "dispute-panel",
+    isDisputed && "dispute-panel--disputed",
+    swap.status === "ResolvedBuyer" && "dispute-panel--resolved-buyer",
+    swap.status === "ResolvedSeller" && "dispute-panel--resolved-seller",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={panelClass}>
+      <div className="dispute-panel__header">
+        <span className="dispute-panel__title">Dispute</span>
+        {dispute && (
+          <span
+            className={`dispute-panel__outcome-badge dispute-panel__outcome-badge--${
+              dispute.outcome === "Pending"
+                ? "pending"
+                : dispute.outcome === "FavorBuyer"
+                ? "buyer"
+                : "seller"
+            }`}
+          >
+            {outcomeLabel(dispute.outcome)}
+          </span>
+        )}
+      </div>
+
+      {/* ── Raise dispute (buyer, while swap is Completed) ── */}
+      {isCompleted && isBuyer && !dispute && (
+        <div className="dispute-actions">
+          <p style={{ fontSize: "0.82rem", color: "#64748b", margin: "0 0 8px" }}>
+            If the delivered content does not match the listing, raise a dispute
+            before the window closes.
+          </p>
+          <button
+            className="dispute-btn dispute-btn--danger"
+            onClick={handleRaiseDispute}
+            disabled={loading}
+          >
+            {loading ? "Raising…" : "Raise Dispute"}
+          </button>
+        </div>
+      )}
+
+      {/* ── Active dispute view ── */}
+      {dispute && (
+        <>
+          {/* Timeline */}
+          <DisputeTimeline
+            dispute={dispute}
+            currentLedger={currentLedger}
+            phase={phase}
+          />
+
+          {/* Vote weight bar (once any votes are in) */}
+          {(BigInt(dispute.vote_weight_buyer) > 0n ||
+            BigInt(dispute.vote_weight_seller) > 0n) && (
+            <div className="dispute-votes">
+              <div className="dispute-votes__label">Vote weights</div>
+              <div className="dispute-votes__bar">
+                <div
+                  className="dispute-votes__bar-buyer"
+                  style={{ width: `${buyerPct}%` }}
+                />
+                <div
+                  className="dispute-votes__bar-seller"
+                  style={{ width: `${sellerPct}%` }}
+                />
+              </div>
+              <div className="dispute-votes__legend">
+                <span className="dispute-votes__legend-buyer">
+                  Buyer {dispute.vote_weight_buyer}
+                </span>
+                <span className="dispute-votes__legend-seller">
+                  Seller {dispute.vote_weight_seller}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Evidence list */}
+          {evidence.length > 0 && (
+            <div className="dispute-evidence">
+              <div className="dispute-evidence__title">
+                Evidence ({evidence.length})
+              </div>
+              <ul className="dispute-evidence__list">
+                {evidence.map((ev, i) => (
+                  <li key={i} className="dispute-evidence__item">
+                    <div>
+                      <div className="dispute-evidence__hash">{ev.ipfs_hash}</div>
+                      <div className="dispute-evidence__submitter">
+                        by {shortAddr(ev.submitter)} · ledger{" "}
+                        {ev.submitted_at_ledger}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="dispute-actions">
+            {/* Evidence submission (buyer or seller while disputed) */}
+            {isDisputed && phase !== "closed" && (
+              <div className="dispute-action-group">
+                <div className="dispute-action-group__title">Submit Evidence</div>
+                <div className="dispute-form">
+                  <div className="dispute-form__row">
+                    <input
+                      className="dispute-form__input"
+                      placeholder="IPFS hash (e.g. QmXyz…)"
+                      value={ipfsInput}
+                      onChange={(e) => setIpfsInput(e.target.value)}
+                    />
+                    <button
+                      className="dispute-btn dispute-btn--neutral"
+                      onClick={handleSubmitEvidence}
+                      disabled={loading}
+                    >
+                      {loading ? "…" : "Submit"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Arbiter commit vote */}
+            {isDisputed && phase === "commit" && (
+              <div className="dispute-action-group">
+                <div className="dispute-action-group__title">
+                  Commit Vote (Arbiter)
+                </div>
+                <div className="dispute-form">
+                  <div className="dispute-form__row">
+                    <select
+                      className="dispute-form__select"
+                      value={voteChoice}
+                      onChange={(e) =>
+                        setVoteChoice(e.target.value as "buyer" | "seller")
+                      }
+                    >
+                      <option value="buyer">Favour Buyer</option>
+                      <option value="seller">Favour Seller</option>
+                    </select>
+                    <input
+                      className="dispute-form__input"
+                      placeholder="Secret salt"
+                      value={voteSalt}
+                      onChange={(e) => setVoteSalt(e.target.value)}
+                    />
+                    <button
+                      className="dispute-btn dispute-btn--primary"
+                      onClick={handleCommitVote}
+                      disabled={loading}
+                    >
+                      {loading ? "…" : "Commit"}
+                    </button>
+                  </div>
+                  <span className="dispute-form__hint">
+                    Save your salt — you must provide it again during the reveal
+                    phase.
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* Arbiter reveal vote */}
+            {isDisputed && phase === "reveal" && (
+              <div className="dispute-action-group">
+                <div className="dispute-action-group__title">
+                  Reveal Vote (Arbiter)
+                </div>
+                <div className="dispute-form">
+                  <div className="dispute-form__row">
+                    <select
+                      className="dispute-form__select"
+                      value={revealChoice}
+                      onChange={(e) =>
+                        setRevealChoice(e.target.value as "buyer" | "seller")
+                      }
+                    >
+                      <option value="buyer">Favour Buyer</option>
+                      <option value="seller">Favour Seller</option>
+                    </select>
+                    <input
+                      className="dispute-form__input"
+                      placeholder="Salt used at commit time"
+                      value={revealSalt}
+                      onChange={(e) => setRevealSalt(e.target.value)}
+                    />
+                    <button
+                      className="dispute-btn dispute-btn--success"
+                      onClick={handleRevealVote}
+                      disabled={loading}
+                    >
+                      {loading ? "…" : "Reveal"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Finalize (anyone, after reveal window) */}
+            {canFinalize && (
+              <div className="dispute-action-group">
+                <div className="dispute-action-group__title">
+                  Finalize Dispute
+                </div>
+                <p style={{ fontSize: "0.78rem", color: "#64748b", margin: "0 0 8px" }}>
+                  The reveal window has closed. Finalize to distribute funds
+                  according to arbiter vote weights.
+                </p>
+                <button
+                  className="dispute-btn dispute-btn--warning"
+                  onClick={handleFinalize}
+                  disabled={loading}
+                >
+                  {loading ? "Finalizing…" : "Finalize Dispute"}
+                </button>
+              </div>
+            )}
+
+            {/* Appeal (buyer, after resolution, within window) */}
+            {canAppeal && (
+              <div className="dispute-action-group">
+                <div className="dispute-action-group__title">Appeal</div>
+                <p style={{ fontSize: "0.78rem", color: "#64748b", margin: "0 0 8px" }}>
+                  You may appeal this outcome for admin review.
+                </p>
+                <button
+                  className="dispute-btn dispute-btn--danger"
+                  onClick={handleAppeal}
+                  disabled={loading}
+                >
+                  {loading ? "Appealing…" : "Appeal Outcome"}
+                </button>
+              </div>
+            )}
+
+            {/* Appealed notice */}
+            {dispute.is_appealed && (
+              <div className="dispute-panel__appealed-notice">
+                This dispute has been appealed and is pending admin review.
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {error && <div className="dispute-panel__error">{error}</div>}
+      {success && <div className="dispute-panel__success">{success}</div>}
+    </div>
+  );
+}
+
+// ── Sub-component: Timeline ────────────────────────────────────────────────────
+
+interface TimelineProps {
+  dispute: DisputeRecord;
+  currentLedger: number;
+  phase: Phase | null;
+}
+
+function DisputeTimeline({ dispute, currentLedger, phase }: TimelineProps) {
+  type Step = {
+    label: string;
+    ledger?: number;
+    status: "done" | "active" | "future";
+  };
+
+  const steps: Step[] = [
+    {
+      label: "Dispute raised",
+      ledger: dispute.raised_at_ledger,
+      status: "done",
+    },
+    {
+      label: `Commit window (closes ledger ${dispute.commit_deadline_ledger})`,
+      ledger: dispute.commit_deadline_ledger,
+      status:
+        phase === "commit" ? "active" : currentLedger > dispute.commit_deadline_ledger ? "done" : "future",
+    },
+    {
+      label: `Reveal window (closes ledger ${dispute.reveal_deadline_ledger})`,
+      ledger: dispute.reveal_deadline_ledger,
+      status:
+        phase === "reveal" ? "active" : currentLedger > dispute.reveal_deadline_ledger ? "done" : "future",
+    },
+    {
+      label:
+        dispute.outcome !== "Pending"
+          ? `Finalized at ledger ${dispute.resolved_at_ledger ?? "—"}`
+          : "Finalize (after reveal window)",
+      status: dispute.outcome !== "Pending" ? "done" : "future",
+    },
+  ];
+
+  if (dispute.appeal_deadline_ledger != null) {
+    steps.push({
+      label: dispute.is_appealed
+        ? "Appealed — awaiting admin review"
+        : `Appeal window (closes ledger ${dispute.appeal_deadline_ledger})`,
+      ledger: dispute.appeal_deadline_ledger,
+      status:
+        dispute.is_appealed
+          ? "active"
+          : currentLedger > dispute.appeal_deadline_ledger
+          ? "done"
+          : "future",
+    });
+  }
+
+  return (
+    <ul className="dispute-timeline">
+      {steps.map((step, i) => (
+        <li key={i} className="dispute-timeline__item">
+          <div className={`dispute-timeline__dot dispute-timeline__dot--${step.status}`} />
+          <span className="dispute-timeline__label">{step.label}</span>
+          {step.ledger != null && (
+            <span className="dispute-timeline__ledger">#{step.ledger}</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/SwapCard.tsx
+++ b/frontend/src/components/SwapCard.tsx
@@ -1,5 +1,6 @@
 import { CancelSwapButton } from "./CancelSwapButton";
 import { ConfirmSwapForm } from "./ConfirmSwapForm";
+import { DisputePanel } from "./DisputePanel";
 import type { Wallet } from "../lib/walletKit";
 import type { Swap } from "../hooks/useMySwaps";
 import "./SwapCard.css";
@@ -50,6 +51,11 @@ export function SwapCard({
           onSuccess={onSwapUpdated}
         />
       )}
+      <DisputePanel
+        swap={swap}
+        wallet={wallet}
+        onSwapUpdated={onSwapUpdated}
+      />
     </div>
   );
 }

--- a/frontend/src/lib/contractClient.ts
+++ b/frontend/src/lib/contractClient.ts
@@ -744,6 +744,309 @@ export async function setMerkleRoot(
   await submitAndPoll(tx, wallet, server);
 }
 
+// ─── Dispute resolution ───────────────────────────────────────────────────────
+
+export interface DisputeRecord {
+  swap_id: number;
+  raised_by: string;
+  raised_at_ledger: number;
+  evidence_count: number;
+  outcome: "Pending" | "FavorBuyer" | "FavorSeller";
+  resolved_at_ledger: number | null;
+  vote_weight_buyer: string;
+  vote_weight_seller: string;
+  commit_deadline_ledger: number;
+  reveal_deadline_ledger: number;
+  appeal_deadline_ledger: number | null;
+  is_appealed: boolean;
+}
+
+export interface EvidenceItem {
+  submitter: string;
+  ipfs_hash: string;
+  submitted_at_ledger: number;
+}
+
+function decodeDisputeScVal(
+  scVal: import("@stellar/stellar-sdk").xdr.ScVal | undefined
+): DisputeRecord | null {
+  if (!scVal || scVal.switch().name === "scvVoid") return null;
+  const native = StellarSdk.scValToNative(scVal);
+  if (!native || typeof native !== "object") return null;
+
+  const outcome =
+    typeof native.outcome === "object" && native.outcome !== null
+      ? (native.outcome.tag as "Pending" | "FavorBuyer" | "FavorSeller")
+      : "Pending";
+
+  const toNum = (v: any) => (v != null ? Number(v) : null);
+
+  return {
+    swap_id: Number(native.swap_id ?? 0),
+    raised_by: String(native.raised_by ?? ""),
+    raised_at_ledger: Number(native.raised_at_ledger ?? 0),
+    evidence_count: Number(native.evidence_count ?? 0),
+    outcome,
+    resolved_at_ledger: toNum(native.resolved_at_ledger),
+    vote_weight_buyer: String(native.vote_weight_buyer ?? "0"),
+    vote_weight_seller: String(native.vote_weight_seller ?? "0"),
+    commit_deadline_ledger: Number(native.commit_deadline_ledger ?? 0),
+    reveal_deadline_ledger: Number(native.reveal_deadline_ledger ?? 0),
+    appeal_deadline_ledger: toNum(native.appeal_deadline_ledger),
+    is_appealed: Boolean(native.is_appealed),
+  };
+}
+
+export async function getDispute(swapId: number): Promise<DisputeRecord | null> {
+  const retval = await simulateView("get_dispute", [
+    StellarSdk.nativeToScVal(swapId, { type: "u64" }),
+  ]);
+  return decodeDisputeScVal(retval);
+}
+
+export async function getEvidence(
+  swapId: number,
+  index: number
+): Promise<EvidenceItem | null> {
+  const retval = await simulateView("get_evidence", [
+    StellarSdk.nativeToScVal(swapId, { type: "u64" }),
+    StellarSdk.nativeToScVal(index, { type: "u32" }),
+  ]);
+  if (!retval || retval.switch().name === "scvVoid") return null;
+  const native = StellarSdk.scValToNative(retval);
+  if (!native || typeof native !== "object") return null;
+  const hashRaw = native.ipfs_hash;
+  const ipfsHash =
+    hashRaw instanceof Uint8Array || Buffer.isBuffer(hashRaw)
+      ? Buffer.from(hashRaw).toString("utf8")
+      : String(hashRaw ?? "");
+  return {
+    submitter: String(native.submitter ?? ""),
+    ipfs_hash: ipfsHash,
+    submitted_at_ledger: Number(native.submitted_at_ledger ?? 0),
+  };
+}
+
+export async function getArbiters(): Promise<string[]> {
+  const retval = await simulateView("get_arbiters", []);
+  if (!retval) return [];
+  const arr = StellarSdk.scValToNative(retval);
+  if (!Array.isArray(arr)) return [];
+  return arr.map(String);
+}
+
+export async function getCurrentLedger(): Promise<number> {
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const ledger = await server.getLatestLedger();
+  return ledger.sequence;
+}
+
+export async function raiseDispute(
+  swapId: number,
+  wallet: { address: string; signTransaction: (xdr: string) => Promise<string> }
+): Promise<void> {
+  if (!ATOMIC_SWAP_CONTRACT_ID)
+    throw new Error("VITE_CONTRACT_ATOMIC_SWAP is not configured.");
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const sourceAccount = await server.getAccount(wallet.address);
+  const contract = new StellarSdk.Contract(ATOMIC_SWAP_CONTRACT_ID);
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "raise_dispute",
+        StellarSdk.nativeToScVal(swapId, { type: "u64" })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  await submitAndPoll(tx, wallet, server);
+}
+
+export async function submitEvidence(
+  swapId: number,
+  ipfsHash: string,
+  wallet: { address: string; signTransaction: (xdr: string) => Promise<string> }
+): Promise<void> {
+  if (!ATOMIC_SWAP_CONTRACT_ID)
+    throw new Error("VITE_CONTRACT_ATOMIC_SWAP is not configured.");
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const sourceAccount = await server.getAccount(wallet.address);
+  const contract = new StellarSdk.Contract(ATOMIC_SWAP_CONTRACT_ID);
+
+  const hashBytes = Buffer.from(ipfsHash, "utf8");
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "submit_evidence",
+        StellarSdk.nativeToScVal(swapId, { type: "u64" }),
+        StellarSdk.nativeToScVal(new StellarSdk.Address(wallet.address), {
+          type: "address",
+        }),
+        StellarSdk.xdr.ScVal.scvBytes(hashBytes)
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  await submitAndPoll(tx, wallet, server);
+}
+
+/**
+ * Compute the commitment hash for the commitment-reveal voting pattern.
+ * commitment = sha256(vote_byte || utf8(salt))
+ * Returns a 32-byte Buffer.
+ */
+export async function computeVoteCommitment(
+  favorBuyer: boolean,
+  salt: string
+): Promise<Buffer> {
+  const voteByte = favorBuyer ? 0x01 : 0x00;
+  const saltBytes = Buffer.from(salt, "utf8");
+  const preimage = Buffer.concat([Buffer.from([voteByte]), saltBytes]);
+
+  const hashBuffer = await crypto.subtle.digest("SHA-256", preimage);
+  return Buffer.from(hashBuffer);
+}
+
+export async function commitVote(
+  swapId: number,
+  favorBuyer: boolean,
+  salt: string,
+  wallet: { address: string; signTransaction: (xdr: string) => Promise<string> }
+): Promise<void> {
+  if (!ATOMIC_SWAP_CONTRACT_ID)
+    throw new Error("VITE_CONTRACT_ATOMIC_SWAP is not configured.");
+
+  const commitment = await computeVoteCommitment(favorBuyer, salt);
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const sourceAccount = await server.getAccount(wallet.address);
+  const contract = new StellarSdk.Contract(ATOMIC_SWAP_CONTRACT_ID);
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "commit_vote",
+        StellarSdk.nativeToScVal(swapId, { type: "u64" }),
+        StellarSdk.nativeToScVal(new StellarSdk.Address(wallet.address), {
+          type: "address",
+        }),
+        StellarSdk.xdr.ScVal.scvBytes(commitment)
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  await submitAndPoll(tx, wallet, server);
+}
+
+export async function revealVote(
+  swapId: number,
+  favorBuyer: boolean,
+  salt: string,
+  wallet: { address: string; signTransaction: (xdr: string) => Promise<string> }
+): Promise<void> {
+  if (!ATOMIC_SWAP_CONTRACT_ID)
+    throw new Error("VITE_CONTRACT_ATOMIC_SWAP is not configured.");
+
+  const saltBytes = Buffer.from(salt, "utf8");
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const sourceAccount = await server.getAccount(wallet.address);
+  const contract = new StellarSdk.Contract(ATOMIC_SWAP_CONTRACT_ID);
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "reveal_vote",
+        StellarSdk.nativeToScVal(swapId, { type: "u64" }),
+        StellarSdk.nativeToScVal(new StellarSdk.Address(wallet.address), {
+          type: "address",
+        }),
+        StellarSdk.xdr.ScVal.scvBool(favorBuyer),
+        StellarSdk.xdr.ScVal.scvBytes(saltBytes)
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  await submitAndPoll(tx, wallet, server);
+}
+
+export async function finalizeDispute(
+  swapId: number,
+  wallet: { address: string; signTransaction: (xdr: string) => Promise<string> }
+): Promise<void> {
+  if (!ATOMIC_SWAP_CONTRACT_ID)
+    throw new Error("VITE_CONTRACT_ATOMIC_SWAP is not configured.");
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const sourceAccount = await server.getAccount(wallet.address);
+  const contract = new StellarSdk.Contract(ATOMIC_SWAP_CONTRACT_ID);
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "finalize_dispute",
+        StellarSdk.nativeToScVal(swapId, { type: "u64" })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  await submitAndPoll(tx, wallet, server);
+}
+
+export async function appealDispute(
+  swapId: number,
+  wallet: { address: string; signTransaction: (xdr: string) => Promise<string> }
+): Promise<void> {
+  if (!ATOMIC_SWAP_CONTRACT_ID)
+    throw new Error("VITE_CONTRACT_ATOMIC_SWAP is not configured.");
+
+  const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+  const sourceAccount = await server.getAccount(wallet.address);
+  const contract = new StellarSdk.Contract(ATOMIC_SWAP_CONTRACT_ID);
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: networkPassphrase(),
+  })
+    .addOperation(
+      contract.call(
+        "appeal_dispute",
+        StellarSdk.nativeToScVal(swapId, { type: "u64" }),
+        StellarSdk.nativeToScVal(new StellarSdk.Address(wallet.address), {
+          type: "address",
+        })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  await submitAndPoll(tx, wallet, server);
+}
+
 export interface Listing {
   id: number;
   owner: string;


### PR DESCRIPTION
- Add Dispute struct and lifecycle functions in atomic_swap: register_arbiter, deactivate_arbiter, submit_evidence, commit_vote, reveal_vote, finalize_dispute, appeal_dispute
- Implement arbiter registry with weighted voting and conflict-of-interest checks
- Implement commitment-reveal pattern (sha256(vote_byte||salt)) to preserve arbiter anonymity until the reveal phase
- Add dispute_window_active check; raise_dispute now creates a Dispute record with configurable commit/reveal windows
- Add resolution timeout (finalize after reveal_deadline) and appeal period (buyer may appeal within appeal_deadline)
- Refactor resolve_dispute to use shared distribute_dispute_funds helper
- Add 13 new ContractError codes (25-37) for dispute phases
- Add 19 integration tests covering full dispute lifecycle, double-vote prevention, commitment verification, appeal enforcement, and tie-breaking
- Add DisputePanel frontend component with evidence upload, arbiter commit/reveal vote forms, vote-weight bar, and dispute timeline view
- Integrate DisputePanel into SwapCard
- Add dispute contractClient functions: getDispute, getEvidence, raiseDispute, submitEvidence, commitVote, revealVote, finalizeDispute, appealDispute

closes #678 