### PR TITLE
feat: implement notification system for swap events and marketplace updates

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,8 @@
     <div id="network-root"></div>
     <!-- React wallet connect button portal target -->
     <div id="wallet-root"></div>
+    <!-- React notification bell portal target -->
+    <div id="notif-bell-root"></div>
     <!-- React buyer swaps dashboard portal target -->
     <div id="dashboard-root"></div>
     <!-- React seller listings dashboard portal target -->

--- a/frontend/src/components/MyListingsDashboard.tsx
+++ b/frontend/src/components/MyListingsDashboard.tsx
@@ -1,9 +1,10 @@
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useMyListings } from "../hooks/useMyListings";
 import { ListingCard } from "./ListingCard";
 import { RegisterListingForm } from "./RegisterListingForm";
 import { useWallet } from "../context/WalletContext";
+import { useNotifications } from "../context/NotificationContext";
 import "./MyListingsDashboard.css";
 
 /**
@@ -20,6 +21,30 @@ export function MyListingsDashboard() {
     wallet?.address ?? null
   );
   const [showRegisterForm, setShowRegisterForm] = useState(false);
+  const { send } = useNotifications();
+
+  // Track listing IDs we have already notified about so we only fire once
+  // per session when a new listing appears (e.g. after RegisterListingForm success).
+  const notifiedListingIds = useRef(new Set<number>());
+
+  useEffect(() => {
+    for (const listing of listings) {
+      if (!notifiedListingIds.current.has(listing.id)) {
+        // Only send the notification if the set was already populated (i.e.
+        // not on the very first load, which would spam every existing listing).
+        if (notifiedListingIds.current.size > 0) {
+          send(
+            "listing_created",
+            "Listing Registered",
+            `Your IP has been registered as Listing #${listing.id} on the marketplace.`,
+            "success",
+            { meta: { listingId: listing.id } }
+          );
+        }
+        notifiedListingIds.current.add(listing.id);
+      }
+    }
+  }, [listings, send]);
 
   if (!wallet) {
     return (

--- a/frontend/src/components/MySwapsDashboard.tsx
+++ b/frontend/src/components/MySwapsDashboard.tsx
@@ -1,12 +1,16 @@
 
 import { useWallet } from "../context/WalletContext";
 import { useMySwaps } from "../hooks/useMySwaps";
+import { useSwapNotifications } from "../context/NotificationContext";
 import { SwapCard } from "./SwapCard";
 import "./MySwapsDashboard.css";
 
 export function MySwapsDashboard() {
   const { wallet } = useWallet();
   const { swaps, ledgerTimestamp, loading, error, refresh } = useMySwaps(wallet?.address ?? null);
+
+  // Fire notifications on swap status transitions
+  useSwapNotifications(swaps, wallet?.address ?? null);
 
   if (!wallet) {
     return (

--- a/frontend/src/components/NotificationBell.css
+++ b/frontend/src/components/NotificationBell.css
@@ -1,0 +1,85 @@
+/* NotificationBell — bell button + dropdown panel */
+
+.nb {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.nb__btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: none;
+  border: 1px solid var(--border-color, #e2e8f0);
+  cursor: pointer;
+  color: var(--foreground, #0f172a);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.nb__btn:hover {
+  background: var(--secondary, #f1f5f9);
+  border-color: var(--primary, #7c3aed);
+}
+
+.nb__btn:focus-visible {
+  outline: 2px solid var(--primary, #7c3aed);
+  outline-offset: 2px;
+}
+
+.nb__icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+/* Unread badge */
+.nb__badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--destructive, #ef4444);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+  pointer-events: none;
+  transform: translate(30%, -30%);
+}
+
+/* Dropdown panel */
+.nb__panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 1000;
+  width: 380px;
+  max-width: calc(100vw - 32px);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14);
+  background: var(--background, #fff);
+  border: 1px solid var(--border-color, #e2e8f0);
+  overflow: hidden;
+  animation: nb-pop 0.15s ease;
+}
+
+@keyframes nb-pop {
+  from { opacity: 0; transform: scale(0.97) translateY(-6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* Responsive: on small screens open full-width anchored to right edge */
+@media (max-width: 480px) {
+  .nb__panel {
+    right: -8px;
+  }
+}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect, useRef } from "react";
+import { useNotifications } from "../context/NotificationContext";
+import { NotificationHistory } from "./NotificationHistory";
+import "./NotificationBell.css";
+
+/**
+ * NotificationBell
+ *
+ * Bell icon button with unread badge. Clicking opens the NotificationHistory
+ * panel in a dropdown.
+ */
+export function NotificationBell() {
+  const { unreadCount } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open]);
+
+  return (
+    <div className="nb" ref={wrapperRef}>
+      <button
+        className="nb__btn"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ""}`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+      >
+        {/* Bell icon (inline SVG so no extra dep) */}
+        <svg
+          className="nb__icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+        {unreadCount > 0 && (
+          <span className="nb__badge" aria-hidden="true">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="nb__panel"
+          role="dialog"
+          aria-modal="false"
+          aria-label="Notifications panel"
+        >
+          <NotificationHistory onClose={() => setOpen(false)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NotificationHistory.css
+++ b/frontend/src/components/NotificationHistory.css
@@ -1,0 +1,262 @@
+/* NotificationHistory — tabbed panel inside NotificationBell dropdown */
+
+.nh {
+  display: flex;
+  flex-direction: column;
+  max-height: 520px;
+  overflow: hidden;
+}
+
+/* Header */
+.nh__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 16px 0;
+}
+
+.nh__title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--foreground, #0f172a);
+  margin: 0;
+}
+
+.nh__close {
+  background: none;
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--muted-foreground, #64748b);
+  padding: 0;
+  transition: color 0.15s;
+}
+.nh__close:hover { color: var(--foreground, #0f172a); }
+
+/* Tabs */
+.nh__tabs {
+  display: flex;
+  gap: 0;
+  padding: 12px 16px 0;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  margin-top: 8px;
+}
+
+.nh__tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 4px;
+  font-size: 12px;
+  font-weight: 600;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  color: var(--muted-foreground, #64748b);
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.nh__tab:hover {
+  color: var(--foreground, #0f172a);
+}
+
+.nh__tab--active {
+  color: var(--primary, #7c3aed);
+  border-bottom-color: var(--primary, #7c3aed);
+}
+
+.nh__tab-badge {
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--primary, #7c3aed);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+}
+
+.nh__tab-badge--muted {
+  background: var(--muted, #f1f5f9);
+  color: var(--muted-foreground, #64748b);
+}
+
+/* Panel */
+.nh__panel {
+  overflow-y: auto;
+  flex: 1;
+  max-height: 400px;
+}
+
+/* Actions bar */
+.nh__actions {
+  display: flex;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+}
+
+.nh__action-btn {
+  background: none;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--muted-foreground, #64748b);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.nh__action-btn:hover {
+  background: var(--secondary, #f1f5f9);
+  color: var(--foreground, #0f172a);
+}
+
+.nh__action-btn--danger:hover {
+  border-color: var(--destructive, #ef4444);
+  color: var(--destructive, #ef4444);
+  background: rgba(239, 68, 68, 0.06);
+}
+
+/* Empty state */
+.nh__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 16px;
+  color: var(--muted-foreground, #64748b);
+  font-size: 13px;
+}
+
+.nh__empty-icon {
+  font-size: 28px;
+  line-height: 1;
+}
+
+/* List */
+.nh__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Item link wrapper */
+.nh__item-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Single notification row */
+.nh__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  cursor: pointer;
+  transition: background 0.12s;
+  position: relative;
+}
+
+.nh__item:last-child {
+  border-bottom: none;
+}
+
+.nh__item:hover {
+  background: var(--secondary, #f8fafc);
+}
+
+.nh__item--unread {
+  background: rgba(124, 58, 237, 0.04);
+}
+.nh__item--unread:hover {
+  background: rgba(124, 58, 237, 0.08);
+}
+
+/* Severity dot */
+.nh__item-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 5px;
+}
+
+.nh__item--info .nh__item-dot    { background: #3b82f6; }
+.nh__item--success .nh__item-dot { background: #22c55e; }
+.nh__item--warning .nh__item-dot { background: #f59e0b; }
+.nh__item--error .nh__item-dot   { background: #ef4444; }
+
+/* Item body */
+.nh__item-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.nh__item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 3px;
+}
+
+.nh__item-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--foreground, #0f172a);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nh__item-time {
+  font-size: 10px;
+  color: var(--muted-foreground, #94a3b8);
+  flex-shrink: 0;
+}
+
+.nh__item-message {
+  font-size: 11px;
+  color: var(--muted-foreground, #64748b);
+  margin: 0;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Archive button */
+.nh__item-archive {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted-foreground, #94a3b8);
+  font-size: 14px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+
+.nh__item:hover .nh__item-archive {
+  opacity: 1;
+}
+
+.nh__item-archive:hover {
+  color: var(--foreground, #0f172a);
+  background: var(--secondary, #f1f5f9);
+}

--- a/frontend/src/components/NotificationHistory.tsx
+++ b/frontend/src/components/NotificationHistory.tsx
@@ -1,0 +1,249 @@
+import { useState } from "react";
+import { useNotifications } from "../context/NotificationContext";
+import type { AppNotification } from "../services/notificationService";
+import { NotificationPreferences } from "./NotificationPreferences";
+import "./NotificationHistory.css";
+
+interface Props {
+  onClose: () => void;
+}
+
+type Tab = "inbox" | "archive" | "settings";
+
+/**
+ * NotificationHistory
+ *
+ * Three-tab panel rendered inside NotificationBell's dropdown:
+ *  - Inbox: unread + read (non-archived)
+ *  - Archive: archived entries
+ *  - Settings: NotificationPreferences UI
+ */
+export function NotificationHistory({ onClose }: Props) {
+  const {
+    notifications,
+    unreadCount,
+    getFullHistory,
+    markRead,
+    markAllRead,
+    archive,
+    archiveAll,
+    clearHistory,
+  } = useNotifications();
+
+  const [tab, setTab] = useState<Tab>("inbox");
+
+  const archived = getFullHistory().filter((n) => n.archived);
+  const inbox = notifications; // already excludes archived
+
+  return (
+    <div className="nh">
+      {/* Header */}
+      <div className="nh__header">
+        <h3 className="nh__title">Notifications</h3>
+        <button className="nh__close" onClick={onClose} aria-label="Close notifications">
+          ×
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="nh__tabs" role="tablist">
+        <button
+          className={`nh__tab ${tab === "inbox" ? "nh__tab--active" : ""}`}
+          role="tab"
+          aria-selected={tab === "inbox"}
+          onClick={() => setTab("inbox")}
+        >
+          Inbox
+          {unreadCount > 0 && (
+            <span className="nh__tab-badge">{unreadCount > 99 ? "99+" : unreadCount}</span>
+          )}
+        </button>
+        <button
+          className={`nh__tab ${tab === "archive" ? "nh__tab--active" : ""}`}
+          role="tab"
+          aria-selected={tab === "archive"}
+          onClick={() => setTab("archive")}
+        >
+          Archive
+          {archived.length > 0 && (
+            <span className="nh__tab-badge nh__tab-badge--muted">{archived.length}</span>
+          )}
+        </button>
+        <button
+          className={`nh__tab ${tab === "settings" ? "nh__tab--active" : ""}`}
+          role="tab"
+          aria-selected={tab === "settings"}
+          onClick={() => setTab("settings")}
+        >
+          Settings
+        </button>
+      </div>
+
+      {/* Tab panels */}
+      {tab === "inbox" && (
+        <InboxPanel
+          items={inbox}
+          onMarkRead={markRead}
+          onMarkAllRead={markAllRead}
+          onArchive={archive}
+          onArchiveAll={archiveAll}
+        />
+      )}
+
+      {tab === "archive" && (
+        <ArchivePanel
+          items={archived}
+          onClear={clearHistory}
+        />
+      )}
+
+      {tab === "settings" && <NotificationPreferences />}
+    </div>
+  );
+}
+
+// ─── Inbox panel ───────────────────────────────────────────────────────────────
+
+interface InboxPanelProps {
+  items: AppNotification[];
+  onMarkRead: (id: string) => void;
+  onMarkAllRead: () => void;
+  onArchive: (id: string) => void;
+  onArchiveAll: () => void;
+}
+
+function InboxPanel({ items, onMarkRead, onMarkAllRead, onArchive, onArchiveAll }: InboxPanelProps) {
+  const hasUnread = items.some((n) => !n.read);
+
+  return (
+    <div className="nh__panel" role="tabpanel">
+      {items.length > 0 && (
+        <div className="nh__actions">
+          {hasUnread && (
+            <button className="nh__action-btn" onClick={onMarkAllRead}>
+              Mark all read
+            </button>
+          )}
+          <button className="nh__action-btn" onClick={onArchiveAll}>
+            Archive all
+          </button>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="nh__empty">
+          <span className="nh__empty-icon" aria-hidden="true">🔔</span>
+          <p>No notifications yet.</p>
+        </div>
+      ) : (
+        <ul className="nh__list" role="list">
+          {items.map((n) => (
+            <NotificationItem
+              key={n.id}
+              notification={n}
+              onMarkRead={onMarkRead}
+              onArchive={onArchive}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ─── Archive panel ─────────────────────────────────────────────────────────────
+
+interface ArchivePanelProps {
+  items: AppNotification[];
+  onClear: () => void;
+}
+
+function ArchivePanel({ items, onClear }: ArchivePanelProps) {
+  return (
+    <div className="nh__panel" role="tabpanel">
+      {items.length > 0 && (
+        <div className="nh__actions">
+          <button className="nh__action-btn nh__action-btn--danger" onClick={onClear}>
+            Clear all history
+          </button>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="nh__empty">
+          <span className="nh__empty-icon" aria-hidden="true">📂</span>
+          <p>Archive is empty.</p>
+        </div>
+      ) : (
+        <ul className="nh__list" role="list">
+          {items.map((n) => (
+            <NotificationItem key={n.id} notification={n} archived />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ─── Single notification row ───────────────────────────────────────────────────
+
+interface NotificationItemProps {
+  notification: AppNotification;
+  onMarkRead?: (id: string) => void;
+  onArchive?: (id: string) => void;
+  archived?: boolean;
+}
+
+function NotificationItem({ notification: n, onMarkRead, onArchive, archived }: NotificationItemProps) {
+  const timeAgo = formatTimeAgo(n.timestamp);
+
+  const inner = (
+    <li
+      className={`nh__item nh__item--${n.severity} ${!n.read ? "nh__item--unread" : ""}`}
+      onClick={() => onMarkRead?.(n.id)}
+    >
+      <span className="nh__item-dot" aria-hidden="true" />
+      <div className="nh__item-body">
+        <div className="nh__item-header">
+          <span className="nh__item-title">{n.title}</span>
+          <span className="nh__item-time">{timeAgo}</span>
+        </div>
+        <p className="nh__item-message">{n.message}</p>
+      </div>
+      {!archived && onArchive && (
+        <button
+          className="nh__item-archive"
+          onClick={(e) => { e.stopPropagation(); onArchive(n.id); }}
+          aria-label="Archive notification"
+          title="Archive"
+        >
+          ↓
+        </button>
+      )}
+    </li>
+  );
+
+  if (n.href) {
+    return (
+      <a href={n.href} className="nh__item-link" onClick={() => onMarkRead?.(n.id)}>
+        {inner}
+      </a>
+    );
+  }
+
+  return inner;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatTimeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}

--- a/frontend/src/components/NotificationPreferences.css
+++ b/frontend/src/components/NotificationPreferences.css
@@ -1,0 +1,206 @@
+/* NotificationPreferences — settings panel inside notification history */
+
+.np {
+  padding: 12px 16px 16px;
+  overflow-y: auto;
+  max-height: 400px;
+}
+
+/* Section */
+.np__section {
+  margin-bottom: 20px;
+}
+
+.np__section-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted-foreground, #64748b);
+  margin: 0 0 10px;
+}
+
+.np__section-title--sub {
+  margin-top: 12px;
+}
+
+/* Toggle row */
+.np__toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  cursor: pointer;
+}
+
+.np__toggle-row:last-child {
+  border-bottom: none;
+}
+
+.np__toggle-row--compact {
+  padding: 6px 0;
+}
+
+.np__toggle-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.np__toggle-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--foreground, #0f172a);
+}
+
+.np__toggle-desc {
+  font-size: 11px;
+  color: var(--muted-foreground, #64748b);
+  line-height: 1.4;
+}
+
+/* Toggle switch */
+.np__toggle {
+  flex-shrink: 0;
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--muted, #e2e8f0);
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+  padding: 0;
+}
+
+.np__toggle--sm {
+  width: 30px;
+  height: 17px;
+}
+
+.np__toggle--on {
+  background: var(--primary, #7c3aed);
+}
+
+.np__toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s;
+}
+
+.np__toggle--sm .np__toggle-thumb {
+  width: 13px;
+  height: 13px;
+}
+
+.np__toggle--on .np__toggle-thumb {
+  transform: translateX(16px);
+}
+
+.np__toggle--sm.np__toggle--on .np__toggle-thumb {
+  transform: translateX(13px);
+}
+
+.np__toggle:focus-visible {
+  outline: 2px solid var(--primary, #7c3aed);
+  outline-offset: 2px;
+}
+
+/* Inputs */
+.np__input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  font-size: 12px;
+  background: var(--background, #fff);
+  color: var(--foreground, #0f172a);
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.np__input:focus {
+  border-color: var(--primary, #7c3aed);
+}
+
+.np__input--mono {
+  font-family: monospace;
+}
+
+.np__textarea {
+  resize: vertical;
+  min-height: 64px;
+  line-height: 1.5;
+}
+
+/* Hints */
+.np__hint {
+  font-size: 11px;
+  color: var(--muted-foreground, #94a3b8);
+  margin: 6px 0 0;
+  line-height: 1.5;
+}
+
+.np__hint code {
+  font-family: monospace;
+  font-size: 10px;
+  background: var(--secondary, #f1f5f9);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.np__hint-inline {
+  font-size: 10px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--muted-foreground, #94a3b8);
+}
+
+/* Save button */
+.np__save-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+
+.np__save-btn {
+  padding: 6px 16px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--primary, #7c3aed);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.np__save-btn:hover {
+  opacity: 0.88;
+}
+
+.np__save-btn--saved {
+  background: #22c55e;
+}
+
+/* Privacy note */
+.np__privacy-note {
+  font-size: 10px;
+  color: var(--muted-foreground, #94a3b8);
+  line-height: 1.6;
+  margin: 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color, #e2e8f0);
+}

--- a/frontend/src/components/NotificationPreferences.tsx
+++ b/frontend/src/components/NotificationPreferences.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { useNotifications } from "../context/NotificationContext";
+import type { NotificationEventType, NotificationChannel } from "../services/notificationService";
+import "./NotificationPreferences.css";
+
+const CHANNEL_LABELS: Record<NotificationChannel, string> = {
+  in_app: "In-App Toasts",
+  email: "Email",
+  webhook: "Webhook",
+};
+
+const CHANNEL_DESCRIPTIONS: Record<NotificationChannel, string> = {
+  in_app: "Show toast notifications inside the app",
+  email: "Send an email via your configured gateway",
+  webhook: "POST a JSON payload to your webhook URL",
+};
+
+const EVENT_LABELS: Record<NotificationEventType, string> = {
+  swap_initiated: "Swap Initiated",
+  swap_confirmed: "Swap Confirmed",
+  swap_cancelled: "Swap Cancelled",
+  swap_expired: "Swap Expired",
+  swap_disputed: "Swap Disputed",
+  payment_confirmed: "Payment Confirmed",
+  listing_created: "Listing Created",
+  listing_updated: "Listing Updated",
+  marketplace_announcement: "Marketplace Announcements",
+};
+
+const EVENT_DESCRIPTIONS: Record<NotificationEventType, string> = {
+  swap_initiated: "When a buyer initiates a swap on your listing",
+  swap_confirmed: "When a seller confirms your swap",
+  swap_cancelled: "When a swap is cancelled by either party",
+  swap_expired: "When a pending swap passes its expiry time",
+  swap_disputed: "When a swap is flagged as disputed",
+  payment_confirmed: "When USDC payment is released on-chain",
+  listing_created: "When your IP is successfully registered",
+  listing_updated: "When your listing details are changed",
+  marketplace_announcement: "Platform-wide updates and announcements",
+};
+
+/**
+ * NotificationPreferences
+ *
+ * Settings panel rendered in the NotificationHistory "Settings" tab.
+ * Lets users toggle channels, configure email/webhook endpoints,
+ * and opt in/out of specific event types.
+ */
+export function NotificationPreferences() {
+  const { preferences, setChannelEnabled, setEventEnabled, updatePreferences } =
+    useNotifications();
+
+  const [emailDraft, setEmailDraft] = useState(preferences.emailAddress ?? "");
+  const [webhookUrlDraft, setWebhookUrlDraft] = useState(preferences.webhookUrl ?? "");
+  const [webhookHeadersDraft, setWebhookHeadersDraft] = useState(
+    Object.entries(preferences.webhookHeaders ?? {})
+      .map(([k, v]) => `${k}: ${v}`)
+      .join("\n")
+  );
+  const [saved, setSaved] = useState(false);
+
+  const handleSaveEndpoints = () => {
+    // Parse header lines "Key: Value"
+    const headers: Record<string, string> = {};
+    webhookHeadersDraft
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .forEach((line) => {
+        const idx = line.indexOf(":");
+        if (idx > 0) {
+          headers[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+        }
+      });
+
+    updatePreferences({
+      emailAddress: emailDraft.trim(),
+      webhookUrl: webhookUrlDraft.trim(),
+      webhookHeaders: headers,
+    });
+
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  const allEvents = Object.keys(EVENT_LABELS) as NotificationEventType[];
+
+  return (
+    <div className="np">
+      {/* ── Channels ── */}
+      <section className="np__section">
+        <h4 className="np__section-title">Channels</h4>
+        {(Object.keys(CHANNEL_LABELS) as NotificationChannel[]).map((ch) => (
+          <label key={ch} className="np__toggle-row">
+            <div className="np__toggle-info">
+              <span className="np__toggle-label">{CHANNEL_LABELS[ch]}</span>
+              <span className="np__toggle-desc">{CHANNEL_DESCRIPTIONS[ch]}</span>
+            </div>
+            <button
+              className={`np__toggle ${preferences.channels[ch] ? "np__toggle--on" : ""}`}
+              role="switch"
+              aria-checked={preferences.channels[ch]}
+              onClick={() => setChannelEnabled(ch, !preferences.channels[ch])}
+              aria-label={`${CHANNEL_LABELS[ch]} ${preferences.channels[ch] ? "enabled" : "disabled"}`}
+            >
+              <span className="np__toggle-thumb" />
+            </button>
+          </label>
+        ))}
+      </section>
+
+      {/* ── Email endpoint ── */}
+      {preferences.channels.email && (
+        <section className="np__section">
+          <h4 className="np__section-title">Email Address</h4>
+          <input
+            className="np__input"
+            type="email"
+            placeholder="you@example.com"
+            value={emailDraft}
+            onChange={(e) => setEmailDraft(e.target.value)}
+            aria-label="Email address for notifications"
+          />
+          <p className="np__hint">
+            Emails are sent via <code>VITE_EMAIL_WEBHOOK_URL</code> gateway.
+          </p>
+        </section>
+      )}
+
+      {/* ── Webhook endpoint ── */}
+      {preferences.channels.webhook && (
+        <section className="np__section">
+          <h4 className="np__section-title">Webhook URL</h4>
+          <input
+            className="np__input np__input--mono"
+            type="url"
+            placeholder="https://your-server.example.com/webhook"
+            value={webhookUrlDraft}
+            onChange={(e) => setWebhookUrlDraft(e.target.value)}
+            aria-label="Webhook URL"
+          />
+          <h4 className="np__section-title np__section-title--sub">
+            Custom Headers <span className="np__hint-inline">(one per line, Key: Value)</span>
+          </h4>
+          <textarea
+            className="np__input np__input--mono np__textarea"
+            placeholder={"Authorization: Bearer token123\nX-My-Header: value"}
+            value={webhookHeadersDraft}
+            onChange={(e) => setWebhookHeadersDraft(e.target.value)}
+            rows={3}
+            aria-label="Custom webhook headers"
+          />
+        </section>
+      )}
+
+      {/* Save endpoints button */}
+      {(preferences.channels.email || preferences.channels.webhook) && (
+        <div className="np__save-row">
+          <button
+            className={`np__save-btn ${saved ? "np__save-btn--saved" : ""}`}
+            onClick={handleSaveEndpoints}
+          >
+            {saved ? "✓ Saved" : "Save Endpoints"}
+          </button>
+        </div>
+      )}
+
+      {/* ── Event types ── */}
+      <section className="np__section">
+        <h4 className="np__section-title">Event Types</h4>
+        <p className="np__hint">Choose which events you want to be notified about.</p>
+        {allEvents.map((evt) => {
+          // If not explicitly set, default is enabled (true)
+          const enabled = preferences.events[evt] !== false;
+          return (
+            <label key={evt} className="np__toggle-row np__toggle-row--compact">
+              <div className="np__toggle-info">
+                <span className="np__toggle-label">{EVENT_LABELS[evt]}</span>
+                <span className="np__toggle-desc">{EVENT_DESCRIPTIONS[evt]}</span>
+              </div>
+              <button
+                className={`np__toggle np__toggle--sm ${enabled ? "np__toggle--on" : ""}`}
+                role="switch"
+                aria-checked={enabled}
+                onClick={() => setEventEnabled(evt, !enabled)}
+                aria-label={`${EVENT_LABELS[evt]} notifications ${enabled ? "enabled" : "disabled"}`}
+              >
+                <span className="np__toggle-thumb" />
+              </button>
+            </label>
+          );
+        })}
+      </section>
+
+      <p className="np__privacy-note">
+        Your preferences are stored locally. Opt-outs are respected immediately.
+        Email and webhook payloads never include private keys or wallet secrets.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/NotificationToast.css
+++ b/frontend/src/components/NotificationToast.css
@@ -1,0 +1,140 @@
+/* NotificationToast — bottom-right stacked toasts */
+
+.nt-container {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 10px;
+  max-width: 380px;
+  width: calc(100vw - 48px);
+  pointer-events: none;
+}
+
+.nt-toast-link {
+  text-decoration: none;
+  color: inherit;
+  pointer-events: auto;
+}
+
+.nt-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+  background: #ffffff;
+  border-left: 4px solid;
+  pointer-events: auto;
+  animation: nt-slide-in 0.3s ease forwards;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+@keyframes nt-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.nt-toast--exit {
+  opacity: 0;
+  transform: translateX(40px);
+}
+
+/* Severity variants */
+.nt-toast--info {
+  border-color: #3b82f6;
+}
+.nt-toast--success {
+  border-color: #22c55e;
+}
+.nt-toast--warning {
+  border-color: #f59e0b;
+}
+.nt-toast--error {
+  border-color: #ef4444;
+}
+
+/* Dark mode */
+.dark .nt-toast {
+  background: #1e293b;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+/* Icon */
+.nt-toast__icon {
+  font-size: 16px;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+.nt-toast--info .nt-toast__icon { color: #3b82f6; }
+.nt-toast--success .nt-toast__icon { color: #22c55e; }
+.nt-toast--warning .nt-toast__icon { color: #f59e0b; }
+.nt-toast--error .nt-toast__icon { color: #ef4444; }
+
+/* Body */
+.nt-toast__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.nt-toast__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 2px;
+  line-height: 1.3;
+}
+
+.nt-toast__message {
+  font-size: 12px;
+  color: #475569;
+  margin: 0;
+  line-height: 1.5;
+  /* clamp to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.dark .nt-toast__title { color: #f1f5f9; }
+.dark .nt-toast__message { color: #94a3b8; }
+
+/* Close button */
+.nt-toast__close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0;
+  margin-top: -2px;
+  transition: color 0.15s;
+}
+.nt-toast__close:hover {
+  color: #475569;
+}
+.dark .nt-toast__close:hover {
+  color: #cbd5e1;
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  .nt-container {
+    bottom: 16px;
+    right: 16px;
+    width: calc(100vw - 32px);
+  }
+}

--- a/frontend/src/components/NotificationToast.tsx
+++ b/frontend/src/components/NotificationToast.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from "react";
+import type { AppNotification } from "../services/notificationService";
+import { useNotifications } from "../context/NotificationContext";
+import "./NotificationToast.css";
+
+const TOAST_DURATION_MS = 5000;
+const MAX_VISIBLE_TOASTS = 3;
+
+/**
+ * NotificationToast
+ *
+ * Renders a stack of in-app toast notifications in the bottom-right corner.
+ * Automatically dismisses after TOAST_DURATION_MS.
+ * Supports manual dismiss and click-through navigation.
+ */
+export function NotificationToast() {
+  const { notifications, markRead } = useNotifications();
+
+  // Only show the most recent unread notifications as toasts
+  const [toastQueue, setToastQueue] = useState<AppNotification[]>([]);
+  const seenIds = useRef(new Set<string>());
+
+  useEffect(() => {
+    const fresh = notifications.filter(
+      (n) => !n.read && !seenIds.current.has(n.id)
+    );
+    if (fresh.length === 0) return;
+
+    for (const n of fresh) {
+      seenIds.current.add(n.id);
+    }
+
+    setToastQueue((prev) => [...fresh, ...prev].slice(0, MAX_VISIBLE_TOASTS));
+  }, [notifications]);
+
+  const dismiss = (id: string) => {
+    markRead(id);
+    setToastQueue((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  if (toastQueue.length === 0) return null;
+
+  return (
+    <div
+      className="nt-container"
+      role="region"
+      aria-label="Notifications"
+      aria-live="polite"
+      aria-atomic="false"
+    >
+      {toastQueue.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onDismiss={dismiss} />
+      ))}
+    </div>
+  );
+}
+
+interface ToastItemProps {
+  toast: AppNotification;
+  onDismiss: (id: string) => void;
+}
+
+function ToastItem({ toast, onDismiss }: ToastItemProps) {
+  const [exiting, setExiting] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const startExit = () => {
+    setExiting(true);
+    setTimeout(() => onDismiss(toast.id), 300); // match CSS transition
+  };
+
+  useEffect(() => {
+    timerRef.current = setTimeout(startExit, TOAST_DURATION_MS);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const icon = severityIcon(toast.severity);
+
+  const content = (
+    <div
+      className={`nt-toast nt-toast--${toast.severity} ${exiting ? "nt-toast--exit" : ""}`}
+      role="alert"
+      aria-live="assertive"
+    >
+      <span className="nt-toast__icon" aria-hidden="true">
+        {icon}
+      </span>
+      <div className="nt-toast__body">
+        <p className="nt-toast__title">{toast.title}</p>
+        <p className="nt-toast__message">{toast.message}</p>
+      </div>
+      <button
+        className="nt-toast__close"
+        onClick={(e) => {
+          e.stopPropagation();
+          startExit();
+        }}
+        aria-label="Dismiss notification"
+      >
+        ×
+      </button>
+    </div>
+  );
+
+  if (toast.href) {
+    return (
+      <a
+        href={toast.href}
+        className="nt-toast-link"
+        onClick={() => onDismiss(toast.id)}
+        aria-label={`${toast.title} — click to view`}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+}
+
+function severityIcon(severity: AppNotification["severity"]): string {
+  switch (severity) {
+    case "success":
+      return "✓";
+    case "warning":
+      return "⚠";
+    case "error":
+      return "✕";
+    default:
+      return "ℹ";
+  }
+}

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -1,0 +1,293 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+} from "react";
+import {
+  notificationService,
+  type AppNotification,
+  type NotificationPreferences,
+  type NotificationEventType,
+  type NotificationChannel,
+  type NotificationSeverity,
+} from "../services/notificationService";
+import { useWallet } from "./WalletContext";
+
+// ─── Context value ─────────────────────────────────────────────────────────────
+
+interface NotificationContextValue {
+  /** All non-archived notifications */
+  notifications: AppNotification[];
+  /** Count of unread, non-archived notifications */
+  unreadCount: number;
+  /** Current user preferences */
+  preferences: NotificationPreferences;
+
+  /** Send a notification programmatically */
+  send: (
+    eventType: NotificationEventType,
+    title: string,
+    message: string,
+    severity?: NotificationSeverity,
+    opts?: { href?: string; meta?: Record<string, unknown> }
+  ) => Promise<AppNotification | null>;
+
+  markRead: (id: string) => void;
+  markAllRead: () => void;
+  archive: (id: string) => void;
+  archiveAll: () => void;
+  clearHistory: () => void;
+
+  /** Fetch history including archived entries */
+  getFullHistory: () => AppNotification[];
+
+  updatePreferences: (patch: Partial<NotificationPreferences>) => void;
+  setChannelEnabled: (channel: NotificationChannel, enabled: boolean) => void;
+  setEventEnabled: (event: NotificationEventType, enabled: boolean) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+// ─── Provider ──────────────────────────────────────────────────────────────────
+
+export function NotificationProvider({ children }: { children: React.ReactNode }) {
+  const { wallet } = useWallet();
+
+  const [notifications, setNotifications] = useState<AppNotification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [preferences, setPreferences] = useState<NotificationPreferences>(
+    notificationService.getPreferences()
+  );
+
+  // Keep wallet address in sync with service so per-wallet storage keys are correct
+  useEffect(() => {
+    notificationService.setWalletAddress(wallet?.address ?? null);
+    // Re-read state after wallet change
+    setNotifications(notificationService.getHistory(false));
+    setUnreadCount(notificationService.getUnreadCount());
+    setPreferences(notificationService.getPreferences());
+  }, [wallet?.address]);
+
+  // Subscribe to service state changes
+  useEffect(() => {
+    const unsub = notificationService.subscribe(() => {
+      setNotifications(notificationService.getHistory(false));
+      setUnreadCount(notificationService.getUnreadCount());
+      setPreferences(notificationService.getPreferences());
+    });
+    return unsub;
+  }, []);
+
+  const send = useCallback(
+    (
+      eventType: NotificationEventType,
+      title: string,
+      message: string,
+      severity?: NotificationSeverity,
+      opts?: { href?: string; meta?: Record<string, unknown> }
+    ) => notificationService.send(eventType, title, message, severity, opts),
+    []
+  );
+
+  const markRead = useCallback((id: string) => notificationService.markRead(id), []);
+  const markAllRead = useCallback(() => notificationService.markAllRead(), []);
+  const archive = useCallback((id: string) => notificationService.archive(id), []);
+  const archiveAll = useCallback(() => notificationService.archiveAll(), []);
+  const clearHistory = useCallback(() => notificationService.clearHistory(), []);
+  const getFullHistory = useCallback(
+    () => notificationService.getHistory(true),
+    []
+  );
+
+  const updatePreferences = useCallback(
+    (patch: Partial<NotificationPreferences>) => {
+      notificationService.updatePreferences(patch);
+      setPreferences(notificationService.getPreferences());
+    },
+    []
+  );
+
+  const setChannelEnabled = useCallback(
+    (channel: NotificationChannel, enabled: boolean) => {
+      notificationService.setChannelEnabled(channel, enabled);
+      setPreferences(notificationService.getPreferences());
+    },
+    []
+  );
+
+  const setEventEnabled = useCallback(
+    (event: NotificationEventType, enabled: boolean) => {
+      notificationService.setEventEnabled(event, enabled);
+      setPreferences(notificationService.getPreferences());
+    },
+    []
+  );
+
+  return (
+    <NotificationContext.Provider
+      value={{
+        notifications,
+        unreadCount,
+        preferences,
+        send,
+        markRead,
+        markAllRead,
+        archive,
+        archiveAll,
+        clearHistory,
+        getFullHistory,
+        updatePreferences,
+        setChannelEnabled,
+        setEventEnabled,
+      }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+// ─── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useNotifications(): NotificationContextValue {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error("useNotifications must be used inside <NotificationProvider>");
+  }
+  return ctx;
+}
+
+// ─── Swap event watcher ────────────────────────────────────────────────────────
+
+/**
+ * useSwapNotifications
+ *
+ * Watches a list of swaps and fires notifications whenever a swap transitions
+ * to a new status. Call this inside any component that already polls swap data.
+ *
+ * @param swaps        - current list of swaps from useMySwaps
+ * @param walletAddress - connected wallet address (to determine buyer/seller role)
+ */
+export function useSwapNotifications(
+  swaps: Array<{
+    id: number;
+    listing_id: number;
+    buyer: string;
+    seller: string;
+    status: string;
+    usdc_amount: number;
+    expires_at: number;
+  }>,
+  walletAddress: string | null
+): void {
+  const { send } = useNotifications();
+  // Map of swapId → last known status so we only fire on transitions
+  const prevStatusRef = useRef<Map<number, string>>(new Map());
+
+  useEffect(() => {
+    if (!walletAddress) return;
+
+    const now = Math.floor(Date.now() / 1000);
+
+    for (const swap of swaps) {
+      const prev = prevStatusRef.current.get(swap.id);
+      const curr = swap.status;
+      const amountUsdc = swap.usdc_amount / Math.pow(10, 7); // USDC_DECIMALS
+
+      // Only fire if status actually changed (or we're seeing it for the first time)
+      if (prev === curr) continue;
+
+      // Don't notify on initial load for settled swaps (avoids spam on reconnect)
+      if (prev === undefined && curr !== "Pending") {
+        prevStatusRef.current.set(swap.id, curr);
+        continue;
+      }
+
+      prevStatusRef.current.set(swap.id, curr);
+
+      const isBuyer = walletAddress === swap.buyer;
+      const isSeller = walletAddress === swap.seller;
+
+      switch (curr) {
+        case "Pending": {
+          if (prev === undefined && isSeller) {
+            // New pending swap against seller's listing
+            send(
+              "swap_initiated",
+              "New Swap Incoming",
+              `Buyer has initiated Swap #${swap.id} for Listing #${swap.listing_id} (${amountUsdc.toFixed(2)} USDC). Confirm to release the IP.`,
+              "info",
+              { href: `/swap/${swap.id}`, meta: { swapId: swap.id, listingId: swap.listing_id } }
+            );
+          }
+          break;
+        }
+        case "Completed": {
+          if (isBuyer) {
+            send(
+              "swap_confirmed",
+              "Swap Completed",
+              `Swap #${swap.id} completed successfully. You now have access to the IP.`,
+              "success",
+              { href: `/swap/${swap.id}`, meta: { swapId: swap.id } }
+            );
+          }
+          if (isSeller) {
+            send(
+              "payment_confirmed",
+              "Payment Received",
+              `Payment of ${amountUsdc.toFixed(2)} USDC for Swap #${swap.id} has been released to your wallet.`,
+              "success",
+              { href: `/swap/${swap.id}`, meta: { swapId: swap.id, amountUsdc } }
+            );
+          }
+          break;
+        }
+        case "Cancelled": {
+          if (isBuyer) {
+            send(
+              "swap_cancelled",
+              "Swap Cancelled",
+              `Swap #${swap.id} was cancelled. Your USDC has been refunded.`,
+              "warning",
+              { href: `/swap/${swap.id}`, meta: { swapId: swap.id } }
+            );
+          }
+          if (isSeller) {
+            send(
+              "swap_cancelled",
+              "Swap Cancelled by Buyer",
+              `Buyer cancelled Swap #${swap.id} for Listing #${swap.listing_id}.`,
+              "warning",
+              { href: `/swap/${swap.id}`, meta: { swapId: swap.id } }
+            );
+          }
+          break;
+        }
+        case "Disputed": {
+          send(
+            "swap_disputed",
+            "Swap Disputed",
+            `Swap #${swap.id} has been flagged as disputed. Please review.`,
+            "error",
+            { href: `/swap/${swap.id}`, meta: { swapId: swap.id } }
+          );
+          break;
+        }
+      }
+
+      // Expiry warning: fire once when swap is Pending and past expires_at
+      if (curr === "Pending" && isBuyer && now >= swap.expires_at && now < swap.expires_at + 120) {
+        send(
+          "swap_expired",
+          "Swap Expired",
+          `Swap #${swap.id} has expired. You can now cancel it to reclaim your USDC.`,
+          "warning",
+          { href: `/swap/${swap.id}`, meta: { swapId: swap.id } }
+        );
+      }
+    }
+  }, [swaps, walletAddress, send]);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,33 +3,43 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { NetworkProvider } from "./context/NetworkContext";
 import { WalletProvider } from "./context/WalletContext";
+import { NotificationProvider } from "./context/NotificationContext";
 import { NetworkSelector } from "./components/NetworkSelector";
 import { WalletConnectButton } from "./components/WalletConnectButton";
 import { MySwapsDashboard } from "./components/MySwapsDashboard";
 import { MyListingsDashboard } from "./components/MyListingsDashboard";
 import { ListingsPage } from "./components/ListingsPage";
 import { SwapPage } from "./components/SwapPage";
+import { NotificationToast } from "./components/NotificationToast";
+import { NotificationBell } from "./components/NotificationBell";
 
 function App() {
   const networkRoot = document.getElementById("network-root");
   const walletRoot = document.getElementById("wallet-root");
   const dashboardRoot = document.getElementById("dashboard-root");
   const listingsRoot = document.getElementById("listings-dashboard-root");
+  const notifBellRoot = document.getElementById("notif-bell-root");
 
   return (
     <NetworkProvider>
       <WalletProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<ListingsPage />} />
-            <Route path="/swap/:id" element={<SwapPage />} />
-          </Routes>
-        </BrowserRouter>
+        <NotificationProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<ListingsPage />} />
+              <Route path="/swap/:id" element={<SwapPage />} />
+            </Routes>
+          </BrowserRouter>
 
-        {networkRoot && createPortal(<NetworkSelector />, networkRoot)}
-        {walletRoot && createPortal(<WalletConnectButton />, walletRoot)}
-        {dashboardRoot && createPortal(<MySwapsDashboard />, dashboardRoot)}
-        {listingsRoot && createPortal(<MyListingsDashboard />, listingsRoot)}
+          {networkRoot && createPortal(<NetworkSelector />, networkRoot)}
+          {walletRoot && createPortal(<WalletConnectButton />, walletRoot)}
+          {notifBellRoot && createPortal(<NotificationBell />, notifBellRoot)}
+          {dashboardRoot && createPortal(<MySwapsDashboard />, dashboardRoot)}
+          {listingsRoot && createPortal(<MyListingsDashboard />, listingsRoot)}
+
+          {/* Global toast container — renders into document.body */}
+          <NotificationToast />
+        </NotificationProvider>
       </WalletProvider>
     </NetworkProvider>
   );

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,0 +1,544 @@
+/**
+ * NotificationService
+ *
+ * Multi-channel notification service for swap events and marketplace updates.
+ * Supports in-app toasts, email (via external webhook), and webhook delivery.
+ *
+ * Features:
+ *  - Multi-channel: in-app, email, webhook
+ *  - User preference management (per-channel, per-event-type opt-in/out)
+ *  - Rate limiting: max 10 notifications per hour per user
+ *  - Deduplication: prevents identical notifications within a 30s window
+ *  - Notification history with archival (localStorage, max 200 entries)
+ *  - Privacy: all delivery respects user preferences
+ */
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+export type NotificationChannel = "in_app" | "email" | "webhook";
+
+export type NotificationEventType =
+  | "swap_initiated"
+  | "swap_confirmed"
+  | "swap_cancelled"
+  | "swap_expired"
+  | "swap_disputed"
+  | "payment_confirmed"
+  | "listing_created"
+  | "listing_updated"
+  | "marketplace_announcement";
+
+export type NotificationSeverity = "info" | "success" | "warning" | "error";
+
+export interface AppNotification {
+  id: string;
+  eventType: NotificationEventType;
+  title: string;
+  message: string;
+  severity: NotificationSeverity;
+  timestamp: number; // unix ms
+  read: boolean;
+  archived: boolean;
+  /** Optional deep-link within the app (e.g. /swap/42) */
+  href?: string;
+  /** Contextual metadata (swap id, listing id, etc.) */
+  meta?: Record<string, unknown>;
+}
+
+export interface NotificationPreferences {
+  /** Which channels are enabled globally */
+  channels: Record<NotificationChannel, boolean>;
+  /** Per-event opt-in / opt-out. If absent, defaults to true (opted in). */
+  events: Partial<Record<NotificationEventType, boolean>>;
+  /** Email address for email channel */
+  emailAddress?: string;
+  /** Webhook URL for webhook channel */
+  webhookUrl?: string;
+  /** Custom webhook headers (e.g. Authorization) */
+  webhookHeaders?: Record<string, string>;
+}
+
+export interface WebhookPayload {
+  event: NotificationEventType;
+  severity: NotificationSeverity;
+  title: string;
+  message: string;
+  timestamp: number;
+  walletAddress: string;
+  meta?: Record<string, unknown>;
+}
+
+// ─── Constants ─────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY_HISTORY = "notif_history";
+const STORAGE_KEY_PREFS = "notif_prefs";
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const RATE_LIMIT_MAX = 10;
+const DEDUP_WINDOW_MS = 30_000; // 30 seconds
+const MAX_HISTORY = 200;
+
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  channels: {
+    in_app: true,
+    email: false,
+    webhook: false,
+  },
+  events: {},
+  emailAddress: "",
+  webhookUrl: "",
+  webhookHeaders: {},
+};
+
+// ─── Utility ───────────────────────────────────────────────────────────────────
+
+function generateId(): string {
+  return `notif_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function dedupKey(eventType: NotificationEventType, meta?: Record<string, unknown>): string {
+  const metaStr = meta ? JSON.stringify(meta) : "";
+  return `${eventType}:${metaStr}`;
+}
+
+// ─── NotificationService class ─────────────────────────────────────────────────
+
+type Listener = (notifications: AppNotification[]) => void;
+
+export class NotificationService {
+  private history: AppNotification[] = [];
+  private preferences: NotificationPreferences = { ...DEFAULT_PREFERENCES };
+  private listeners = new Set<Listener>();
+
+  /** Map of dedupKey → timestamp of last delivery */
+  private recentDedup = new Map<string, number>();
+
+  /** Timestamps of notifications sent (for rate limiting), per wallet */
+  private rateLimitLog: number[] = [];
+
+  private walletAddress: string | null = null;
+
+  constructor() {
+    this.loadFromStorage();
+  }
+
+  // ─── Lifecycle ─────────────────────────────────────────────────────────────
+
+  /** Call when wallet connects to associate notifications with user. */
+  setWalletAddress(address: string | null): void {
+    this.walletAddress = address;
+    // Reload history / prefs scoped to this wallet
+    this.loadFromStorage();
+  }
+
+  // ─── Subscription ──────────────────────────────────────────────────────────
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    // Immediately deliver current state to new subscriber
+    listener([...this.history]);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(): void {
+    const snapshot = [...this.history];
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+
+  // ─── Core delivery ─────────────────────────────────────────────────────────
+
+  /**
+   * Send a notification through all enabled channels.
+   * Handles preference filtering, rate limiting, and deduplication.
+   */
+  async send(
+    eventType: NotificationEventType,
+    title: string,
+    message: string,
+    severity: NotificationSeverity = "info",
+    opts: { href?: string; meta?: Record<string, unknown> } = {}
+  ): Promise<AppNotification | null> {
+    // 1. Check per-event preference
+    const eventEnabled = this.preferences.events[eventType];
+    if (eventEnabled === false) return null;
+
+    // 2. Deduplication check
+    const key = dedupKey(eventType, opts.meta);
+    const lastSeen = this.recentDedup.get(key);
+    if (lastSeen && Date.now() - lastSeen < DEDUP_WINDOW_MS) {
+      return null;
+    }
+    this.recentDedup.set(key, Date.now());
+
+    // 3. Rate limiting (max 10/hour per user)
+    const now = Date.now();
+    this.rateLimitLog = this.rateLimitLog.filter(
+      (ts) => now - ts < RATE_LIMIT_WINDOW_MS
+    );
+    if (this.rateLimitLog.length >= RATE_LIMIT_MAX) {
+      console.warn("[NotificationService] Rate limit reached, dropping notification:", title);
+      return null;
+    }
+    this.rateLimitLog.push(now);
+
+    // 4. Build notification record
+    const notification: AppNotification = {
+      id: generateId(),
+      eventType,
+      title,
+      message,
+      severity,
+      timestamp: now,
+      read: false,
+      archived: false,
+      href: opts.href,
+      meta: opts.meta,
+    };
+
+    // 5. In-app delivery
+    if (this.preferences.channels.in_app) {
+      this.addToHistory(notification);
+      this.emit();
+    }
+
+    // 6. Email delivery (fire-and-forget, via external webhook)
+    if (this.preferences.channels.email && this.preferences.emailAddress) {
+      this.deliverEmail(notification).catch((err) =>
+        console.error("[NotificationService] Email delivery failed:", err)
+      );
+    }
+
+    // 7. Webhook delivery
+    if (this.preferences.channels.webhook && this.preferences.webhookUrl) {
+      this.deliverWebhook(notification).catch((err) =>
+        console.error("[NotificationService] Webhook delivery failed:", err)
+      );
+    }
+
+    return notification;
+  }
+
+  // ─── In-app history ────────────────────────────────────────────────────────
+
+  private addToHistory(notification: AppNotification): void {
+    this.history = [notification, ...this.history].slice(0, MAX_HISTORY);
+    this.saveHistory();
+  }
+
+  getHistory(includeArchived = false): AppNotification[] {
+    if (includeArchived) return [...this.history];
+    return this.history.filter((n) => !n.archived);
+  }
+
+  getUnreadCount(): number {
+    return this.history.filter((n) => !n.read && !n.archived).length;
+  }
+
+  markRead(id: string): void {
+    const notif = this.history.find((n) => n.id === id);
+    if (notif && !notif.read) {
+      notif.read = true;
+      this.saveHistory();
+      this.emit();
+    }
+  }
+
+  markAllRead(): void {
+    let changed = false;
+    for (const n of this.history) {
+      if (!n.read) {
+        n.read = true;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.saveHistory();
+      this.emit();
+    }
+  }
+
+  archive(id: string): void {
+    const notif = this.history.find((n) => n.id === id);
+    if (notif && !notif.archived) {
+      notif.archived = true;
+      notif.read = true;
+      this.saveHistory();
+      this.emit();
+    }
+  }
+
+  archiveAll(): void {
+    let changed = false;
+    for (const n of this.history) {
+      if (!n.archived) {
+        n.archived = true;
+        n.read = true;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.saveHistory();
+      this.emit();
+    }
+  }
+
+  clearHistory(): void {
+    this.history = [];
+    this.saveHistory();
+    this.emit();
+  }
+
+  // ─── Preferences ───────────────────────────────────────────────────────────
+
+  getPreferences(): NotificationPreferences {
+    return { ...this.preferences };
+  }
+
+  updatePreferences(patch: Partial<NotificationPreferences>): void {
+    this.preferences = {
+      ...this.preferences,
+      ...patch,
+      channels: { ...this.preferences.channels, ...(patch.channels ?? {}) },
+      events: { ...this.preferences.events, ...(patch.events ?? {}) },
+      webhookHeaders: {
+        ...this.preferences.webhookHeaders,
+        ...(patch.webhookHeaders ?? {}),
+      },
+    };
+    this.savePreferences();
+    this.emit();
+  }
+
+  setEventEnabled(eventType: NotificationEventType, enabled: boolean): void {
+    this.preferences.events[eventType] = enabled;
+    this.savePreferences();
+  }
+
+  setChannelEnabled(channel: NotificationChannel, enabled: boolean): void {
+    this.preferences.channels[channel] = enabled;
+    this.savePreferences();
+  }
+
+  // ─── Email delivery ────────────────────────────────────────────────────────
+
+  /**
+   * Email is delivered by posting a structured payload to an email gateway webhook.
+   * This keeps the frontend stateless — a backend or serverless function receives
+   * the payload and dispatches the actual email.
+   *
+   * The endpoint is configured via VITE_EMAIL_WEBHOOK_URL env variable.
+   */
+  private async deliverEmail(notification: AppNotification): Promise<void> {
+    const endpoint = import.meta.env.VITE_EMAIL_WEBHOOK_URL;
+    if (!endpoint) return;
+
+    const payload = {
+      to: this.preferences.emailAddress,
+      subject: `[Atomic IP] ${notification.title}`,
+      body: notification.message,
+      event: notification.eventType,
+      severity: notification.severity,
+      timestamp: notification.timestamp,
+      meta: notification.meta,
+    };
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Email gateway responded with ${response.status}`);
+    }
+  }
+
+  // ─── Webhook delivery ──────────────────────────────────────────────────────
+
+  /**
+   * POST a structured webhook payload to the user-configured URL.
+   * Standard headers plus any user-defined custom headers (e.g. Authorization).
+   */
+  private async deliverWebhook(notification: AppNotification): Promise<void> {
+    const url = this.preferences.webhookUrl;
+    if (!url) return;
+
+    const payload: WebhookPayload = {
+      event: notification.eventType,
+      severity: notification.severity,
+      title: notification.title,
+      message: notification.message,
+      timestamp: notification.timestamp,
+      walletAddress: this.walletAddress ?? "",
+      meta: notification.meta,
+    };
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-Atomic-IP-Event": notification.eventType,
+      "X-Atomic-IP-Severity": notification.severity,
+      ...this.preferences.webhookHeaders,
+    };
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Webhook endpoint responded with ${response.status}`);
+    }
+  }
+
+  // ─── Persistence ───────────────────────────────────────────────────────────
+
+  private storageKey(suffix: string): string {
+    const wallet = this.walletAddress ?? "anon";
+    return `${suffix}_${wallet}`;
+  }
+
+  private saveHistory(): void {
+    try {
+      localStorage.setItem(
+        this.storageKey(STORAGE_KEY_HISTORY),
+        JSON.stringify(this.history)
+      );
+    } catch {
+      // localStorage quota exceeded — prune old entries and retry once
+      this.history = this.history.slice(0, Math.floor(MAX_HISTORY / 2));
+      try {
+        localStorage.setItem(
+          this.storageKey(STORAGE_KEY_HISTORY),
+          JSON.stringify(this.history)
+        );
+      } catch {
+        // silent fail
+      }
+    }
+  }
+
+  private savePreferences(): void {
+    try {
+      localStorage.setItem(
+        this.storageKey(STORAGE_KEY_PREFS),
+        JSON.stringify(this.preferences)
+      );
+    } catch {
+      // silent fail
+    }
+  }
+
+  private loadFromStorage(): void {
+    // Load history
+    try {
+      const raw = localStorage.getItem(this.storageKey(STORAGE_KEY_HISTORY));
+      this.history = raw ? (JSON.parse(raw) as AppNotification[]) : [];
+    } catch {
+      this.history = [];
+    }
+
+    // Load preferences
+    try {
+      const raw = localStorage.getItem(this.storageKey(STORAGE_KEY_PREFS));
+      if (raw) {
+        const saved = JSON.parse(raw) as Partial<NotificationPreferences>;
+        this.preferences = {
+          ...DEFAULT_PREFERENCES,
+          ...saved,
+          channels: { ...DEFAULT_PREFERENCES.channels, ...(saved.channels ?? {}) },
+          events: { ...DEFAULT_PREFERENCES.events, ...(saved.events ?? {}) },
+        };
+      } else {
+        this.preferences = { ...DEFAULT_PREFERENCES };
+      }
+    } catch {
+      this.preferences = { ...DEFAULT_PREFERENCES };
+    }
+  }
+}
+
+// ─── Singleton ─────────────────────────────────────────────────────────────────
+
+export const notificationService = new NotificationService();
+
+// ─── Convenience factory helpers ───────────────────────────────────────────────
+
+/**
+ * Predefined notification templates for each marketplace event.
+ * Each factory returns the args to pass to notificationService.send().
+ */
+export const NotificationTemplates = {
+  swapInitiated: (swapId: number, listingId: number, amountUsdc: number) => ({
+    eventType: "swap_initiated" as NotificationEventType,
+    title: "Swap Initiated",
+    message: `A buyer has initiated Swap #${swapId} for Listing #${listingId} (${amountUsdc.toFixed(2)} USDC). Review and confirm to release the IP.`,
+    severity: "info" as NotificationSeverity,
+    opts: { href: `/swap/${swapId}`, meta: { swapId, listingId, amountUsdc } },
+  }),
+
+  swapConfirmed: (swapId: number, listingId: number, amountUsdc: number) => ({
+    eventType: "swap_confirmed" as NotificationEventType,
+    title: "Swap Confirmed",
+    message: `Swap #${swapId} for Listing #${listingId} was confirmed. ${amountUsdc.toFixed(2)} USDC has been released.`,
+    severity: "success" as NotificationSeverity,
+    opts: { href: `/swap/${swapId}`, meta: { swapId, listingId, amountUsdc } },
+  }),
+
+  swapCancelled: (swapId: number) => ({
+    eventType: "swap_cancelled" as NotificationEventType,
+    title: "Swap Cancelled",
+    message: `Swap #${swapId} has been cancelled and your USDC refunded.`,
+    severity: "warning" as NotificationSeverity,
+    opts: { href: `/swap/${swapId}`, meta: { swapId } },
+  }),
+
+  swapExpired: (swapId: number) => ({
+    eventType: "swap_expired" as NotificationEventType,
+    title: "Swap Expired",
+    message: `Swap #${swapId} has expired. You can now cancel it to reclaim your USDC.`,
+    severity: "warning" as NotificationSeverity,
+    opts: { href: `/swap/${swapId}`, meta: { swapId } },
+  }),
+
+  swapDisputed: (swapId: number) => ({
+    eventType: "swap_disputed" as NotificationEventType,
+    title: "Swap Disputed",
+    message: `Swap #${swapId} has been flagged as disputed. Please review the details.`,
+    severity: "error" as NotificationSeverity,
+    opts: { href: `/swap/${swapId}`, meta: { swapId } },
+  }),
+
+  paymentConfirmed: (swapId: number, amountUsdc: number) => ({
+    eventType: "payment_confirmed" as NotificationEventType,
+    title: "Payment Confirmed",
+    message: `Payment of ${amountUsdc.toFixed(2)} USDC for Swap #${swapId} has been confirmed on-chain.`,
+    severity: "success" as NotificationSeverity,
+    opts: { href: `/swap/${swapId}`, meta: { swapId, amountUsdc } },
+  }),
+
+  listingCreated: (listingId: number) => ({
+    eventType: "listing_created" as NotificationEventType,
+    title: "Listing Registered",
+    message: `Your IP has been registered as Listing #${listingId} on the marketplace.`,
+    severity: "success" as NotificationSeverity,
+    opts: { meta: { listingId } },
+  }),
+
+  listingUpdated: (listingId: number, field: string) => ({
+    eventType: "listing_updated" as NotificationEventType,
+    title: "Listing Updated",
+    message: `Listing #${listingId} has been updated: ${field} changed.`,
+    severity: "info" as NotificationSeverity,
+    opts: { meta: { listingId, field } },
+  }),
+
+  marketplaceAnnouncement: (text: string) => ({
+    eventType: "marketplace_announcement" as NotificationEventType,
+    title: "Marketplace Update",
+    message: text,
+    severity: "info" as NotificationSeverity,
+    opts: {},
+  }),
+} as const;


### PR DESCRIPTION
## Summary

Implements a comprehensive notification system for the Atomic IP Marketplace, covering swap status changes, payment confirmations, listing events, and marketplace announcements across multiple delivery channels.

Closes #691

---

## Changes

### New: `NotificationService` (`src/services/notificationService.ts`)
- Multi-channel delivery: **in-app toasts**, **email** (via configurable gateway webhook), and **webhook** (user-defined URL + custom headers)
- Rate limiting: max **10 notifications per hour** per wallet — excess notifications are dropped with a console warning
- **30-second deduplication window** to prevent duplicate events from rapid poll cycles
- Notification history persisted to **localStorage** (max 200 entries, per-wallet scoped)
- User preferences (channel toggles, event opt-outs, endpoints) also persisted per-wallet
- `NotificationTemplates` factory helpers for all 9 event types

### New: `NotificationContext` (`src/context/NotificationContext.tsx`)
- `NotificationProvider` wraps the app and syncs service state to React
- `useNotifications()` hook exposes send, markRead, archive, clearHistory, updatePreferences
- `useSwapNotifications(swaps, walletAddress)` — watches swap arrays and fires on status transitions without double-firing on initial load or reconnect

### New: UI Components
| Component | Description |
|---|---|
| `NotificationToast` | Bottom-right stacked toasts, auto-dismiss 5s, slide animation, severity variants, click-through nav |
| `NotificationBell` | Bell icon with live unread badge, dropdown on click, closes on outside-click/Escape |
| `NotificationHistory` | Three-tab panel: Inbox, Archive, Settings |
| `NotificationPreferences` | Toggle switches per channel and per event type, email + webhook endpoint config, privacy note |

### Modified: Integration
- `main.tsx` — wrapped in `NotificationProvider`, global `NotificationToast`, `NotificationBell` portalled into `#notif-bell-root`
- `index.html` — added `<div id="notif-bell-root">` mount point
- `MySwapsDashboard` — calls `useSwapNotifications` on every poll cycle
- `MyListingsDashboard` — fires `listing_created` notification on new listings

---

## Notification Event Taxonomy

| Event | Trigger |
|---|---|
| `swap_initiated` | Seller sees new pending swap on their listing |
| `swap_confirmed` | Buyer's swap transitions to Completed |
| `swap_cancelled` | Either party sees cancellation |
| `swap_expired` | Pending swap passes `expires_at` |
| `swap_disputed` | Swap flagged as Disputed |
| `payment_confirmed` | USDC released to seller on completion |
| `listing_created` | New listing appears after registration |
| `listing_updated` | Listing field changed |
| `marketplace_announcement` | Platform-wide updates |

---

## Privacy & Security
- Email and webhook payloads **never include private keys or wallet secrets**
- All delivery respects user opt-outs immediately
- Webhook uses user-supplied URL + headers only; no third-party calls without explicit config
- Preferences and history are scoped per wallet address in localStorage

---

## Testing
- TypeScript strict check passes with **zero errors**
- Rate limiting: send >10 notifications rapidly → 11th is dropped
- Deduplication: same event type + meta within 30s → second is dropped
- Swap status transitions fire correct notification per buyer/seller role
- Settled swaps on initial load do not spam notifications on reconnect
- Preferences persist across page reload